### PR TITLE
feat(cli): witness exchange for multi-signature transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ spel --idl program-idl.json -p program.bin \
   --co-signer <account-id> --export handover.json -- \
   admin-transfer --caller <current-admin> --evidence <new-admin> ...
 
+# --export and --co-signer are global flags and belong before the "--"
+# separator. Misplaced after it they are rejected with an error, the CLI
+# never falls through to a live submission.
+
 # The file travels to the co-signer over any channel.
 
 # Machine B: inspect and sign. Shows the summary embedded by machine A

--- a/README.md
+++ b/README.md
@@ -332,6 +332,49 @@ spel inspect 0000...0000 \
   --data 00<32-byte-definition-id-hex>00000000000000000000000000000064
 ```
 
+### Multi-Signature Transactions (Witness Exchange)
+
+Some instructions need signatures from accounts whose keys live on
+different machines. A transaction's authorization is checked against its
+witness set, so all signers must sign the same message bytes, and those
+bytes contain every signer's nonce. The CLI coordinates this through a
+partial-transaction file that travels between signers.
+
+```bash
+# Machine A: build the full transaction, sign with local keys, and write
+# the partial transaction to a file instead of submitting. Repeat
+# --co-signer for each additional required signer. Needs a node
+# connection to fetch nonces for all signers.
+spel --idl program-idl.json -p program.bin \
+  --co-signer <account-id> --export handover.json -- \
+  admin-transfer --caller <current-admin> --evidence <new-admin> ...
+
+# The file travels to the co-signer over any channel.
+
+# Machine B: inspect and sign. Shows the summary embedded by machine A
+# next to fields decoded locally from the message bytes, asks for
+# confirmation, then signs for every required signer whose key this
+# wallet holds. Works offline.
+spel sign handover.json
+
+# Anyone: submit once all witnesses are collected. Needs a node.
+spel submit handover.json
+```
+
+The file is JSON: the borsh-serialized message in hex, the ordered list
+of required signers, and the collected witnesses. The signers order
+matches the nonce order inside the message. The full format is
+documented in `spel-cli/src/blob.rs`.
+
+A partial transaction goes stale when any listed signer's on-chain
+nonce changes. Signing and submitting verify the collected witnesses
+first and fail with a clear error in that case, and the flow restarts
+with a fresh export.
+
+`--export` works without `--co-signer` too, for preparing a transaction
+on one machine and submitting it from another. It only supports public
+transactions and cannot be combined with `--dry-run`.
+
 ## Crates
 
 | Crate | Description |

--- a/README.md
+++ b/README.md
@@ -366,10 +366,20 @@ of required signers, and the collected witnesses. The signers order
 matches the nonce order inside the message. The full format is
 documented in `spel-cli/src/blob.rs`.
 
+A signature authorizes exactly the message bytes in the file being
+signed, and every already-collected witness is verified against those
+same bytes before signing, so nobody can swap the message under
+existing signatures. What the prompt cannot do is read intent into raw
+instruction data. To verify a blob independently, rebuild the claimed
+transaction on your own machine with the same arguments and `--export`,
+and compare the decoded fields, instruction data included, against
+what the prompt shows. The two exports differ only in nonces fetched
+at different times.
+
 A partial transaction goes stale when any listed signer's on-chain
-nonce changes. Signing and submitting verify the collected witnesses
-first and fail with a clear error in that case, and the flow restarts
-with a fresh export.
+nonce changes. Signing is a local operation and cannot detect this,
+staleness surfaces at submission, which fails with a clear error, and
+the flow restarts with a fresh export.
 
 `--export` works without `--co-signer` too, for preparing a transaction
 on one machine and submitting it from another. It only supports public

--- a/spel-cli/src/blob.rs
+++ b/spel-cli/src/blob.rs
@@ -22,20 +22,22 @@
 //! - `summary`: human-readable rendering of the transaction, produced by
 //!   the exporting CLI from the built bytes
 //! - `message_hex`: borsh-serialized nssa `Message`, hex. Signatures are
-//!   made over exactly these bytes
+//!   made over the 32-byte hash of these bytes
 //! - `signers`: account ids ("0x" plus hex) that must sign. The order
 //!   matches the nonce order inside the message and dictates the witness
 //!   order when the final transaction is assembled
 //! - `witnesses`: map from account id to `{pubkey, signature}`, both hex
 //!
 //! A blob goes stale when any listed signer's on-chain nonce changes,
-//! because the nonces inside `message_hex` no longer match. Signing or
-//! submitting a stale blob fails, and the flow restarts with a fresh
-//! export.
+//! because the nonces inside `message_hex` no longer match. Signing is
+//! a local operation and cannot notice, staleness surfaces when the
+//! transaction is submitted, and the flow restarts with a fresh export.
 //!
-//! Trust model v1: co-signers decide based on the embedded `summary`,
-//! trusting the exporting CLI to have rendered it from the real bytes.
-//! Independent decoding of `message_hex` against an IDL is a planned
+//! Trust model v1: the sign prompt decodes the operative content from
+//! `message_hex` itself, program id, account ids, nonces and the raw
+//! instruction data as hex, so a co-signer never depends on the
+//! exporter's `summary` for what they are signing. Decoding the
+//! instruction data against an IDL into named args is a planned
 //! upgrade.
 //!
 //! The format only depends on nssa types and borsh plus JSON encoding, so
@@ -55,7 +57,8 @@ use crate::hex::{decode_bytes_32, hex_decode};
 pub struct WitnessEntry {
     /// Schnorr public key, hex. Validated as a curve point on parse.
     pub pubkey: PublicKey,
-    /// Schnorr signature over the message bytes, hex (64 bytes).
+    /// Schnorr signature over the 32-byte hash of the message bytes,
+    /// hex (64 bytes).
     pub signature: String,
 }
 
@@ -67,7 +70,8 @@ pub struct TxBlob {
     /// Human-readable summary rendered by the exporting CLI. Trust model v1:
     /// co-signers read this before signing.
     pub summary: String,
-    /// Borsh-serialized nssa Message, hex. These exact bytes get signed.
+    /// Borsh-serialized nssa Message, hex. Signatures are made over the
+    /// 32-byte hash of these bytes.
     pub message_hex: String,
     /// Account ids ("0x" + hex) that must sign. ORDER MATTERS: it matches
     /// the nonce order inside the message and dictates witness order at submit.
@@ -106,9 +110,9 @@ impl TxBlob {
     }
 
     /// Raw message bytes. Signatures are made over and verified against
-    /// exactly these bytes.
+    /// the 32-byte hash of these bytes.
     pub fn message_bytes(&self) -> Result<Vec<u8>, String> {
-        hex_decode(&self.message_hex).map_err(|e| format!("blog message_hex: {}", e))
+        hex_decode(&self.message_hex).map_err(|e| format!("blob message_hex: {}", e))
     }
 
     /// Decoded message, for display and for assembling the final transaction.

--- a/spel-cli/src/blob.rs
+++ b/spel-cli/src/blob.rs
@@ -128,7 +128,8 @@ impl TxBlob {
     /// Check every collected witness: signature must verify over the stored
     /// message bytes, and pubkey must derive the claimed account id.
     pub fn verify_witnesses(&self) -> Result<(), String> {
-        let bytes = self.message_bytes()?;
+        // v0.2.0: witnesses sign the 32-byte message hash, not the raw bytes.
+        let message_hash = self.message()?.hash();
         for (account_id, entry) in &self.witnesses {
             let sig = entry.signature.parse::<Signature>().map_err(|e| {
                 format!(
@@ -136,7 +137,7 @@ impl TxBlob {
                     account_id, e
                 )
             })?;
-            if !sig.is_valid_for(&bytes, &entry.pubkey) {
+            if !sig.is_valid_for(&message_hash, &entry.pubkey) {
                 return Err(format!(
                     "witness for '{}' does not verify against the message \
                     (stale nonce or corrupted blob?)",
@@ -185,10 +186,9 @@ mod tests {
     use crate::hex::hex_encode;
 
     fn witness_entry(message: &Message, key: &PrivateKey) -> WitnessEntry {
-        let bytes = borsh::to_vec(&message).unwrap();
-        let signature = Signature::new(&key, &bytes);
+        let signature = Signature::new(key, &message.hash());
 
-        let pubkey = PublicKey::new_from_private_key(&key);
+        let pubkey = PublicKey::new_from_private_key(key);
         WitnessEntry {
             pubkey,
             signature: signature.to_string(),
@@ -283,9 +283,20 @@ mod tests {
 
     #[test]
     fn verify_rejects_tampered_message() {
-        let (mut blob, _key) = signed_blob();
+        let (mut blob, key) = signed_blob();
 
-        blob.message_hex = "11".to_string();
+        // Tamper: swap in a different (still-decodable) message. Its hash no
+        // longer matches what the witness signed, so verification must reject it.
+        let pubkey = PublicKey::new_from_private_key(&key);
+        let account_id = AccountId::from(&pubkey);
+        let tampered = Message::try_new(
+            [0; 8],
+            vec![account_id],
+            vec![1_u128.into()],
+            vec![9, 9, 9, 9],
+        )
+        .unwrap();
+        blob.message_hex = hex_encode(&borsh::to_vec(&tampered).unwrap());
 
         let err = blob.verify_witnesses().unwrap_err();
         assert!(
@@ -302,7 +313,7 @@ mod tests {
         // Attacker: different key, but a perfectly VALID signature over the message.
         let attacker_key = PrivateKey::try_new([2; 32]).unwrap();
         let attacker_pubkey = PublicKey::new_from_private_key(&attacker_key);
-        let signature = Signature::new(&attacker_key, &blob.message_bytes().unwrap());
+        let signature = Signature::new(&attacker_key, &blob.message().unwrap().hash());
 
         // Claim it as the legitimate signer's witness.
         let victim_id = blob.signers[0].clone();

--- a/spel-cli/src/blob.rs
+++ b/spel-cli/src/blob.rs
@@ -44,7 +44,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 
-use nssa::public_transaction::Message;
+use nssa::public_transaction::{Message, WitnessSet};
 use nssa::{AccountId, PublicKey, Signature};
 use serde::{Deserialize, Serialize};
 
@@ -156,13 +156,44 @@ impl TxBlob {
         }
         Ok(())
     }
+
+    /// Assemble the final witness set IN SIGNERS ORDER, which matches the
+    /// nonce order inside the message. Fails if any signer has no witness.
+    pub fn witness_set(&self) -> Result<WitnessSet, String> {
+        let mut witnesses_pairs: Vec<(Signature, PublicKey)> = Vec::new();
+        for id in &self.signers {
+            let entry = self
+                .witnesses
+                .get(id)
+                .ok_or_else(|| format!("no witness for '{}'", id))?;
+            let sig = entry
+                .signature
+                .parse::<Signature>()
+                .map_err(|e| format!("witness for '{}' has malformed signature: {}", id, e))?;
+            witnesses_pairs.push((sig, entry.pubkey.clone()));
+        }
+
+        Ok(WitnessSet::from_raw_parts(witnesses_pairs))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hex::{hex_decode, hex_encode};
     use nssa::PrivateKey;
+
+    use crate::hex::hex_encode;
+
+    fn witness_entry(message: &Message, key: &PrivateKey) -> WitnessEntry {
+        let bytes = borsh::to_vec(&message).unwrap();
+        let signature = Signature::new(&key, &bytes);
+
+        let pubkey = PublicKey::new_from_private_key(&key);
+        WitnessEntry {
+            pubkey,
+            signature: signature.to_string(),
+        }
+    }
 
     /// A valid one-signer blob with a correct witness, plus the key that signed it.
     fn signed_blob() -> (TxBlob, PrivateKey) {
@@ -177,17 +208,10 @@ mod tests {
         )
         .unwrap();
         let bytes = borsh::to_vec(&message).unwrap();
-        let signature = Signature::new(&key, &bytes);
 
         let id = format!("0x{}", hex_encode(account_id.value()));
         let mut witnesses = BTreeMap::new();
-        witnesses.insert(
-            id.clone(),
-            WitnessEntry {
-                pubkey,
-                signature: signature.to_string(),
-            },
-        );
+        witnesses.insert(id.clone(), witness_entry(&message, &key));
         let blob = TxBlob {
             version: 1,
             summary: "test".to_string(),
@@ -304,5 +328,77 @@ mod tests {
         // Remove the witness: its signer must show up.
         blob.witnesses.clear();
         assert_eq!(blob.missing_signers(), vec![&blob.signers[0]]);
+    }
+
+    #[test]
+    fn witness_set_assembles_in_signers_order() {
+        let key = PrivateKey::try_new([1; 32]).unwrap();
+        let pubkey = PublicKey::new_from_private_key(&key);
+
+        // Two made-up ids with KNOWN sort order: "bb..." > "aa...".
+        // signers lists bb first, the map iterates aa first — orders differ.
+        let id_hi = format!("0x{}", "bb".repeat(32));
+        let id_lo = format!("0x{}", "aa".repeat(32));
+
+        let mut witnesses = BTreeMap::new();
+        // Distinct fake signatures so order is observable in the output.
+        witnesses.insert(
+            id_hi.clone(),
+            WitnessEntry {
+                pubkey: pubkey.clone(),
+                signature: "11".repeat(64),
+            },
+        );
+        witnesses.insert(
+            id_lo.clone(),
+            WitnessEntry {
+                pubkey,
+                signature: "22".repeat(64),
+            },
+        );
+        let blob = TxBlob {
+            version: 1,
+            summary: String::new(),
+            message_hex: String::new(), // witness_set never reads it
+            signers: vec![id_hi, id_lo],
+            witnesses,
+        };
+
+        let ws = blob.witness_set().unwrap();
+        let pairs = ws.signatures_and_public_keys();
+        assert_eq!(pairs[0].0.to_string(), "11".repeat(64));
+        assert_eq!(pairs[1].0.to_string(), "22".repeat(64));
+    }
+
+    #[test]
+    fn witness_set_fails_on_missing_witness() {
+        let key = PrivateKey::try_new([1; 32]).unwrap();
+        let pubkey = PublicKey::new_from_private_key(&key);
+
+        // Two made-up ids with KNOWN sort order: "bb..." > "aa...".
+        // signers lists bb first, the map iterates aa first — orders differ.
+        let id_hi = format!("0x{}", "bb".repeat(32));
+        let id_lo = format!("0x{}", "aa".repeat(32));
+
+        let mut witnesses = BTreeMap::new();
+        // Distinct fake signatures so order is observable in the output.
+        witnesses.insert(
+            id_hi.clone(),
+            WitnessEntry {
+                pubkey: pubkey.clone(),
+                signature: "11".repeat(64),
+            },
+        );
+
+        let blob = TxBlob {
+            version: 1,
+            summary: String::new(),
+            message_hex: String::new(), // witness_set never reads it
+            signers: vec![id_hi, id_lo],
+            witnesses,
+        };
+
+        let err = blob.witness_set().unwrap_err();
+        assert!(err.contains("no witness for"), "unexpected error: {}", err)
     }
 }

--- a/spel-cli/src/blob.rs
+++ b/spel-cli/src/blob.rs
@@ -1,0 +1,308 @@
+//! Witness-exchange blob format v1 (multi-signature transaction exchange).
+//!
+//! Some instructions need signatures from accounts whose keys live on
+//! different machines. Authorization is derived from the witness set over
+//! the transaction message, so every signer must sign the same message
+//! bytes, and those bytes already contain every signer's nonce. This module
+//! defines a partial-transaction file that carries the message between
+//! machines while signatures are collected.
+//!
+//! Flow:
+//! 1. The exporting CLI builds the complete message (fetching nonces for
+//!    all signers, including co-signers), signs with the keys its wallet
+//!    holds, and writes the blob instead of submitting.
+//! 2. Each co-signer runs `spel sign <blob>`. The CLI verifies the
+//!    witnesses already present, shows the embedded summary for
+//!    confirmation, appends a witness for every required signer whose key
+//!    the local wallet holds, and writes the file back.
+//! 3. Once no signer is missing, anyone runs `spel submit <blob>`.
+//!
+//! The file is JSON with these fields:
+//! - `version`: format version, this module reads and writes 1
+//! - `summary`: human-readable rendering of the transaction, produced by
+//!   the exporting CLI from the built bytes
+//! - `message_hex`: borsh-serialized nssa `Message`, hex. Signatures are
+//!   made over exactly these bytes
+//! - `signers`: account ids ("0x" plus hex) that must sign. The order
+//!   matches the nonce order inside the message and dictates the witness
+//!   order when the final transaction is assembled
+//! - `witnesses`: map from account id to `{pubkey, signature}`, both hex
+//!
+//! A blob goes stale when any listed signer's on-chain nonce changes,
+//! because the nonces inside `message_hex` no longer match. Signing or
+//! submitting a stale blob fails, and the flow restarts with a fresh
+//! export.
+//!
+//! Trust model v1: co-signers decide based on the embedded `summary`,
+//! trusting the exporting CLI to have rendered it from the real bytes.
+//! Independent decoding of `message_hex` against an IDL is a planned
+//! upgrade.
+//!
+//! The format only depends on nssa types and borsh plus JSON encoding, so
+//! any tool can produce or consume it.
+
+use std::collections::BTreeMap;
+use std::fs;
+
+use nssa::public_transaction::Message;
+use nssa::{AccountId, PublicKey, Signature};
+use serde::{Deserialize, Serialize};
+
+use crate::hex::{decode_bytes_32, hex_decode};
+
+/// One collected signature: who signed (pubkey) and the signature itself.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WitnessEntry {
+    /// Schnorr public key, hex. Validated as a curve point on parse.
+    pub pubkey: PublicKey,
+    /// Schnorr signature over the message bytes, hex (64 bytes).
+    pub signature: String,
+}
+
+/// Partial transaction traveling between signers.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TxBlob {
+    /// Format version. This code reads and writes version 1.
+    pub version: u32,
+    /// Human-readable summary rendered by the exporting CLI. Trust model v1:
+    /// co-signers read this before signing.
+    pub summary: String,
+    /// Borsh-serialized nssa Message, hex. These exact bytes get signed.
+    pub message_hex: String,
+    /// Account ids ("0x" + hex) that must sign. ORDER MATTERS: it matches
+    /// the nonce order inside the message and dictates witness order at submit.
+    pub signers: Vec<String>,
+    /// Collected witnesses, keyed by account id from `signers`.
+    pub witnesses: BTreeMap<String, WitnessEntry>,
+}
+
+impl TxBlob {
+    pub fn load(path: &str) -> Result<TxBlob, String> {
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("cannot read blob file '{}': {}", path, e))?;
+        let blob = serde_json::from_str::<TxBlob>(&content)
+            .map_err(|e| format!("invalid blob JSON in '{}': {}", path, e))?;
+        if blob.version != 1 {
+            return Err(format!(
+                "unsupported blob version {}, this CLI supports version 1",
+                blob.version
+            ));
+        }
+
+        for key in blob.witnesses.keys() {
+            if !blob.signers.contains(key) {
+                return Err(format!("witness for '{}' is not in the signers list", key));
+            }
+        }
+
+        Ok(blob)
+    }
+
+    pub fn save(&self, path: &str) -> Result<(), String> {
+        let mut content = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("cannot convert to json: {}", e))?;
+        content.push('\n');
+        fs::write(path, &content).map_err(|e| format!("cannot write blob file '{}': {}", path, e))
+    }
+
+    /// Raw message bytes. Signatures are made over and verified against
+    /// exactly these bytes.
+    pub fn message_bytes(&self) -> Result<Vec<u8>, String> {
+        hex_decode(&self.message_hex).map_err(|e| format!("blog message_hex: {}", e))
+    }
+
+    /// Decoded message, for display and for assembling the final transaction.
+    pub fn message(&self) -> Result<Message, String> {
+        let bytes = self.message_bytes()?;
+        borsh::from_slice::<Message>(&bytes).map_err(|e| format!("cannot decode message: {}", e))
+    }
+
+    /// Signers that have no witness yet.
+    pub fn missing_signers(&self) -> Vec<&String> {
+        self.signers
+            .iter()
+            .filter(|s| !self.witnesses.contains_key(*s))
+            .collect()
+    }
+
+    /// Check every collected witness: signature must verify over the stored
+    /// message bytes, and pubkey must derive the claimed account id.
+    pub fn verify_witnesses(&self) -> Result<(), String> {
+        let bytes = self.message_bytes()?;
+        for (account_id, entry) in &self.witnesses {
+            let sig = entry.signature.parse::<Signature>().map_err(|e| {
+                format!(
+                    "witness for '{}' has malformed signature: {}",
+                    account_id, e
+                )
+            })?;
+            if !sig.is_valid_for(&bytes, &entry.pubkey) {
+                return Err(format!(
+                    "witness for '{}' does not verify against the message \
+                    (stale nonce or corrupted blob?)",
+                    account_id
+                ));
+            }
+            let claimed = decode_bytes_32(account_id)
+                .map_err(|e| format!("invalid account id '{}': {}", account_id, e))?;
+            let derived = AccountId::from(&entry.pubkey);
+            if derived.value() != &claimed {
+                return Err(format!(
+                    "witness for '{}' is signed by a key that does not belong \
+                    to that account",
+                    account_id
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hex::{hex_decode, hex_encode};
+    use nssa::PrivateKey;
+
+    /// A valid one-signer blob with a correct witness, plus the key that signed it.
+    fn signed_blob() -> (TxBlob, PrivateKey) {
+        let key = PrivateKey::try_new([1; 32]).unwrap();
+        let pubkey = PublicKey::new_from_private_key(&key);
+        let account_id = AccountId::from(&pubkey);
+        let message = Message::try_new(
+            [0; 8],
+            vec![account_id],
+            vec![1_u128.into()],
+            vec![1, 2, 3, 4],
+        )
+        .unwrap();
+        let bytes = borsh::to_vec(&message).unwrap();
+        let signature = Signature::new(&key, &bytes);
+
+        let id = format!("0x{}", hex_encode(account_id.value()));
+        let mut witnesses = BTreeMap::new();
+        witnesses.insert(
+            id.clone(),
+            WitnessEntry {
+                pubkey,
+                signature: signature.to_string(),
+            },
+        );
+        let blob = TxBlob {
+            version: 1,
+            summary: "test".to_string(),
+            message_hex: hex_encode(&bytes),
+            signers: vec![id],
+            witnesses,
+        };
+        (blob, key)
+    }
+
+    #[test]
+    fn verify_accepts_valid_witness() {
+        let (blob, _key) = signed_blob();
+        assert!(blob.verify_witnesses().is_ok());
+    }
+
+    #[test]
+    fn roundtrip_save_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_buf = dir.path().join("b.json");
+        let path = path_buf.to_str().unwrap();
+        let (blob, _key) = signed_blob();
+        blob.save(path).unwrap();
+        let loaded = TxBlob::load(path).unwrap();
+
+        assert_eq!(blob.version, loaded.version);
+        assert_eq!(blob.summary, loaded.summary);
+        assert_eq!(blob.message_hex, loaded.message_hex);
+        assert_eq!(blob.signers, loaded.signers);
+    }
+
+    #[test]
+    fn load_rejects_bad_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_buf = dir.path().join("b.json");
+        let path = path_buf.to_str().unwrap();
+        let (mut blob, _key) = signed_blob();
+        blob.version = 2;
+        blob.save(path).unwrap();
+
+        let err = TxBlob::load(path).unwrap_err();
+        assert!(
+            err.contains("unsupported blob version"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn load_rejects_unknown_witness() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_buf = dir.path().join("b.json");
+        let path = path_buf.to_str().unwrap();
+
+        let (mut blob, _key) = signed_blob();
+
+        let entry = blob.witnesses.values().next().unwrap();
+        blob.witnesses
+            .insert(format!("0x{}", "ee".repeat(32)), entry.clone());
+        blob.save(path).unwrap();
+
+        let err = TxBlob::load(path).unwrap_err();
+        assert!(
+            err.contains("not in the signers list"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn verify_rejects_tampered_message() {
+        let (mut blob, _key) = signed_blob();
+
+        blob.message_hex = "11".to_string();
+
+        let err = blob.verify_witnesses().unwrap_err();
+        assert!(
+            err.contains("does not verify against the message"),
+            "unexpected error: {}",
+            err
+        )
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let (mut blob, _key) = signed_blob();
+
+        // Attacker: different key, but a perfectly VALID signature over the message.
+        let attacker_key = PrivateKey::try_new([2; 32]).unwrap();
+        let attacker_pubkey = PublicKey::new_from_private_key(&attacker_key);
+        let signature = Signature::new(&attacker_key, &blob.message_bytes().unwrap());
+
+        // Claim it as the legitimate signer's witness.
+        let victim_id = blob.signers[0].clone();
+        blob.witnesses.insert(
+            victim_id,
+            WitnessEntry {
+                pubkey: attacker_pubkey,
+                signature: signature.to_string(),
+            },
+        );
+
+        let err = blob.verify_witnesses().unwrap_err();
+        assert!(err.contains("does not belong"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn missing_signers_lists_unsigned() {
+        let (mut blob, _key) = signed_blob();
+
+        // Fully signed blob: nothing missing.
+        assert!(blob.missing_signers().is_empty());
+
+        // Remove the witness: its signer must show up.
+        blob.witnesses.clear();
+        assert_eq!(blob.missing_signers(), vec![&blob.signers[0]]);
+    }
+}

--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -135,6 +135,10 @@ pub fn print_instruction_help(ix: &IdlInstruction) {
 /// only legal for boolean args (per the IDL) or the universal `--help`/
 /// `-h`; for anything else we exit with a `missing value` error so a
 /// missing CLI value can't be silently stored as the literal "true".
+///
+/// Keys outside the instruction's vocabulary exit with an error before
+/// any transaction is built: a global flag like `--export` misplaced
+/// after the `--` separator must not fall through to a live submission.
 pub fn parse_instruction_args(
     args: &[String],
     ix: &IdlInstruction,
@@ -171,6 +175,10 @@ pub fn parse_instruction_args(
     if map.contains_key("help") || map.contains_key("h") {
         print_instruction_help(ix);
         std::process::exit(0);
+    }
+    if let Err(msg) = reject_unknown_keys(&map, ix) {
+        eprintln!("{msg}");
+        std::process::exit(1);
     }
 
     map
@@ -225,5 +233,89 @@ pub fn idl_type_hint(ty: &IdlType) -> String {
             IdlType::Primitive(p) if p == "u8" => format!("HEX{}|STR≤{}", array.1 * 2, array.1),
             _ => format!("[_; {}]", array.1),
         },
+    }
+}
+
+/// Rejects any `--key` outside this instruction's vocabulary: its IDL
+/// args and its non-pda accounts, kebab-case. A miss is a typo or a
+/// misplaced global flag, and either must stop the run before a
+/// transaction is built.
+fn reject_unknown_keys(
+    map: &HashMap<String, Vec<String>>,
+    ix: &IdlInstruction,
+) -> Result<(), String> {
+    let known: std::collections::HashSet<String> = ix
+        .args
+        .iter()
+        .map(|a| snake_to_kebab(&a.name))
+        .chain(
+            ix.accounts
+                .iter()
+                .filter(|a| a.pda.is_none())
+                .map(|a| snake_to_kebab(&a.name)),
+        )
+        .collect();
+    match map.keys().find(|k| !known.contains(*k)) {
+        Some(key) => Err(format!(
+            "❌ --{key}: unknown argument for this instruction\n   \
+            Flow flags like --export and --co-signer are global: put them before the '--' separator."
+        )),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One arg, one plain signer account, one PDA account: the smallest
+    /// instruction exercising every vocabulary rule.
+    fn fixture_ix() -> IdlInstruction {
+        serde_json::from_value(serde_json::json!({
+            "name": "do_thing",
+            "accounts": [
+                {
+                    "name": "config",
+                    "pda": { "seeds": [ { "kind": "const", "value": "config" } ] }
+                },
+                { "name": "caller", "signer": true }
+            ],
+            "args": [ { "name": "new_value", "type": "u64" } ]
+        }))
+        .expect("fixture deserializes")
+    }
+
+    fn map_of(keys: &[&str]) -> std::collections::HashMap<String, Vec<String>> {
+        keys.iter()
+            .map(|k| ((*k).to_string(), vec!["x".to_string()]))
+            .collect()
+    }
+
+    #[test]
+    fn full_legal_vocabulary_is_accepted() {
+        let ix = fixture_ix();
+        assert!(reject_unknown_keys(&map_of(&["new-value", "caller"]), &ix).is_ok());
+    }
+
+    // Live-round regression (2026-08-09): --export placed after the '--'
+    // separator was silently dropped and the transaction submitted
+    // instead of exporting.
+    #[test]
+    fn misplaced_global_flag_is_rejected() {
+        let ix = fixture_ix();
+        let err = reject_unknown_keys(&map_of(&["caller", "export"]), &ix).unwrap_err();
+        assert!(err.contains("--export"), "error names the key: {err}");
+        assert!(
+            err.contains("before the '--' separator"),
+            "error points at the fix: {err}"
+        );
+    }
+
+    // PDA accounts are derived, never passed as flags, so their names are
+    // not part of the vocabulary either.
+    #[test]
+    fn pda_account_name_is_not_a_flag() {
+        let ix = fixture_ix();
+        assert!(reject_unknown_keys(&map_of(&["config"]), &ix).is_err());
     }
 }

--- a/spel-cli/src/exchange.rs
+++ b/spel-cli/src/exchange.rs
@@ -1,0 +1,222 @@
+//! `spel sign` and `spel submit`: the CLI half of witness exchange
+
+use std::io::Write;
+use std::{io, process};
+
+use common::transaction::NSSATransaction;
+use nssa::public_transaction::WitnessSet;
+use nssa::{AccountId, PublicKey, PublicTransaction, Signature};
+use sequencer_service_rpc::RpcClient as _;
+use wallet::WalletCore;
+
+use crate::blob::{TxBlob, WitnessEntry};
+use crate::hex::{decode_bytes_32, hex_encode};
+
+/// Load a blob, verify it, show what it is, and append witnesses for
+/// every required signer whose key the local wallet holds.
+pub fn sign_command(path: &str) {
+    let mut blob = TxBlob::load(path).unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);
+    });
+
+    // Refuse to touch a blob whose existing witnesses do not verify:
+    // stale nonces, tampering, or corruption;
+    blob.verify_witnesses().unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);      
+    });
+    
+    let message = blob.message().unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);      
+    });
+
+    // What the exporter claims this transaction does.
+    println!("=== Summary (embedded by exporter) ===");
+    print!("{}", blob.summary);
+    println!();
+
+    // What the bytes actually say. Rendered locally from message_hex,
+    // independent of the summary text.
+    println!("=== Decoded from message bytes ===");
+    let program_id_hex: String = message
+        .program_id
+        .iter()
+        .flat_map(|w| w.to_le_bytes())
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    println!("Program ID: {}", program_id_hex);
+    println!("Accounts:");
+    for id in &message.account_ids {
+        println!("  0x{}", hex_encode(id.value()));
+    }
+    // Nonces pair with the signers list, not with the accounts above.
+    println!("Signer nonces:");
+    for (id, nonce) in blob.signers.iter().zip(message.nonces.iter()) {
+        println!("  {} nonce={}", id, nonce.0);
+    }
+    println!();
+
+    println!("Signers:");
+    for id in &blob.signers {
+        let status = if blob.witnesses.contains_key(id) {
+            "✅ signed"
+        } else {
+            "⏳ missing"
+        };
+        println!("  {} {}", status, id);
+    }
+
+    println!();
+
+    if blob.missing_signers().is_empty() {
+        println!("All witnesses collected. Submit with: spel submit {}", path);
+        return;
+    }
+
+    // Keys this wallet holds for the still-missing signers.
+    let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
+        eprintln!("❌ Failed to initialize wallet: {:?}", e);
+        eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
+        process::exit(1);    
+    });
+
+    let missing: Vec<String> = blob.missing_signers().into_iter().cloned().collect();
+    let mut signable: Vec<(String, &nssa::PrivateKey)> = Vec::new();
+    for id_str in &missing {
+        let bytes = decode_bytes_32(id_str).unwrap_or_else(|e| {
+            eprintln!("❌ invalid signer id '{}': {}", id_str, e);
+            process::exit(1);
+        });
+
+        if let Some(key) = wallet_core
+            .storage()
+            .user_data
+            .get_pub_account_signing_key(AccountId::new(bytes))
+        {
+            signable.push((id_str.clone(), key));
+        }
+    }
+
+    if signable.is_empty() {
+        eprintln!("❌ This wallet holds no key for any missing signer.");
+        process::exit(1);        
+    }
+
+    println!("This wallet can sign for:");
+    for (id, _) in &signable {
+        println!("  {}", id);
+    }
+    print!("Sign and update the file? [y/N] ");
+    io::stdout().flush().unwrap();
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer).unwrap();
+    if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+        println!("Aborted, nothing written.");
+        process::exit(1);
+    }
+
+    let message_bytes = blob.message_bytes().unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);
+    });
+    for (id, key) in signable {
+        let signature = Signature::new(key, &message_bytes);
+        let pubkey = PublicKey::new_from_private_key(key);
+        blob.witnesses.insert(
+            id, 
+        WitnessEntry {
+                pubkey,
+                signature: signature.to_string(),
+            }
+        ); 
+    }
+
+    blob.save(path).unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);
+    });
+
+    println!("✅ Witnesses added, file updated: {}", path);
+    if blob.missing_signers().is_empty() {
+        println!("All witnesses collected. Submit with: spel submit {}", path);
+    } else {
+        println!("Still missing:");
+        for id in blob.missing_signers() {
+            println!("  {}", id);
+        }
+        println!("Send the file to the remaining signers");
+    }
+}
+
+pub async fn submit_command(path: &str) {
+    let blob = TxBlob::load(path).unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);
+    });
+
+    // Refuse to touch a blob whose existing witnesses do not verify:
+    // stale nonces, tampering, or corruption;
+    blob.verify_witnesses().unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);      
+    });
+
+    let message = blob.message().unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);      
+    });
+
+    if !blob.missing_signers().is_empty() {
+        eprintln!("❌ missing signers. run: spel sign <file>");
+        process::exit(1);      
+    }
+
+    let mut witnesses_pairs: Vec<(Signature, PublicKey)>  = Vec::new();
+    for id in &blob.signers {
+        let entry = blob.witnesses.get(id).unwrap_or_else(|| {
+            eprintln!("❌ no witness for '{}'", id);
+            process::exit(1);      
+        });
+        let sig = entry.signature.parse::<Signature>().unwrap_or_else(|e| {
+            eprintln!("❌ {}", e);
+            process::exit(1);
+        });
+        witnesses_pairs.push((sig, entry.pubkey.clone()));
+    }
+
+    let witness_set = WitnessSet::from_raw_parts(witnesses_pairs);
+    let tx = PublicTransaction::new(message, witness_set);
+
+    let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
+        eprintln!("❌ Failed to initialize wallet: {:?}", e);
+        eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
+        process::exit(1);
+    });
+    let tx_hash = wallet_core
+        .sequencer_client
+        .send_transaction(NSSATransaction::Public(tx))
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("❌ Failed to submit transaction: {:?}", e);
+            process::exit(1);
+        });
+
+    println!("📤 Transaction submitted!");
+    println!("   tx_hash: {}", tx_hash);
+    println!("   Waiting for confirmation...");
+
+    let poller = wallet::poller::TxPoller::new(
+        wallet_core.config(),
+        wallet_core.sequencer_client.clone(),
+    );
+
+    match poller.poll_tx(tx_hash).await {
+        Ok(_) => println!("✅ Transaction confirmed — included in a block."),
+        Err(e) => {
+            eprintln!("❌ Transaction NOT confirmed: {e:#}");
+            process::exit(1);
+        },
+    }
+}

--- a/spel-cli/src/exchange.rs
+++ b/spel-cli/src/exchange.rs
@@ -64,6 +64,13 @@ pub fn sign_command(path: &str) {
         .map(|b| format!("{:02x}", b))
         .collect();
     println!("Program ID: {}", program_id_hex);
+    let instruction_data_hex: String = message
+        .instruction_data
+        .iter()
+        .flat_map(|w| w.to_le_bytes())
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    println!("Instruction data: 0x{}", instruction_data_hex);
     println!("Accounts:");
     for id in &message.account_ids {
         println!("  0x{}", hex_encode(id.value()));

--- a/spel-cli/src/exchange.rs
+++ b/spel-cli/src/exchange.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 use std::{io, process};
 
-use common::transaction::NSSATransaction;
+use common::transaction::LeeTransaction;
 use nssa::public_transaction::WitnessSet;
 use nssa::{AccountId, PublicKey, PublicTransaction, Signature};
 use sequencer_service_rpc::RpcClient as _;
@@ -101,11 +101,7 @@ pub fn sign_command(path: &str) {
 
     let missing: Vec<String> = blob.missing_signers().into_iter().cloned().collect();
     let signable = detect_signable(&missing, |id| {
-        wallet_core
-            .storage()
-            .user_data
-            .get_pub_account_signing_key(id)
-            .is_some()
+        wallet_core.get_account_public_signing_key(id).is_some()
     })
     .unwrap_or_else(|e| {
         eprintln!("❌ {}", e);
@@ -130,18 +126,20 @@ pub fn sign_command(path: &str) {
         process::exit(1);
     }
 
-    let message_bytes = blob.message_bytes().unwrap_or_else(|e| {
-        eprintln!("❌ {}", e);
-        process::exit(1);
-    });
+    // v0.2.0: sign the 32-byte message hash, matching WitnessSet::is_valid_for.
+    let message_hash = blob
+        .message()
+        .unwrap_or_else(|e| {
+            eprintln!("❌ {}", e);
+            process::exit(1);
+        })
+        .hash();
     for id in signable {
         let bytes = decode_bytes_32(&id).unwrap();
         let key = wallet_core
-            .storage()
-            .user_data
-            .get_pub_account_signing_key(AccountId::new(bytes))
+            .get_account_public_signing_key(AccountId::new(bytes))
             .expect("key vanished between detection and signing");
-        let signature = Signature::new(key, &message_bytes);
+        let signature = Signature::new(key, &message_hash);
         let pubkey = PublicKey::new_from_private_key(key);
         blob.witnesses.insert(
             id,
@@ -205,7 +203,7 @@ pub async fn submit_command(path: &str) {
     });
     let tx_hash = wallet_core
         .sequencer_client
-        .send_transaction(NSSATransaction::Public(tx))
+        .send_transaction(LeeTransaction::Public(tx))
         .await
         .unwrap_or_else(|e| {
             eprintln!("❌ Failed to submit transaction: {:?}", e);

--- a/spel-cli/src/exchange.rs
+++ b/spel-cli/src/exchange.rs
@@ -12,6 +12,23 @@ use wallet::WalletCore;
 use crate::blob::{TxBlob, WitnessEntry};
 use crate::hex::{decode_bytes_32, hex_encode};
 
+/// Of the missing signer ids, those the key lookup answers for.
+/// Fails on a id that does not decode.
+fn detect_signable(
+    missing: &[String],
+    hold_keys: impl Fn(AccountId) -> bool,
+) -> Result<Vec<String>, String> {
+    let mut out = Vec::new();
+    for id_str in missing {
+        let bytes = decode_bytes_32(id_str)
+            .map_err(|e| format!("invalid signer id '{}': {}", id_str, e))?;
+        if hold_keys(AccountId::new(bytes)) {
+            out.push(id_str.clone());
+        }
+    }
+    Ok(out)
+}
+
 /// Load a blob, verify it, show what it is, and append witnesses for
 /// every required signer whose key the local wallet holds.
 pub fn sign_command(path: &str) {
@@ -24,12 +41,12 @@ pub fn sign_command(path: &str) {
     // stale nonces, tampering, or corruption;
     blob.verify_witnesses().unwrap_or_else(|e| {
         eprintln!("❌ {}", e);
-        process::exit(1);      
+        process::exit(1);
     });
-    
+
     let message = blob.message().unwrap_or_else(|e| {
         eprintln!("❌ {}", e);
-        process::exit(1);      
+        process::exit(1);
     });
 
     // What the exporter claims this transaction does.
@@ -79,33 +96,29 @@ pub fn sign_command(path: &str) {
     let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
         eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
-        process::exit(1);    
+        process::exit(1);
     });
 
     let missing: Vec<String> = blob.missing_signers().into_iter().cloned().collect();
-    let mut signable: Vec<(String, &nssa::PrivateKey)> = Vec::new();
-    for id_str in &missing {
-        let bytes = decode_bytes_32(id_str).unwrap_or_else(|e| {
-            eprintln!("❌ invalid signer id '{}': {}", id_str, e);
-            process::exit(1);
-        });
-
-        if let Some(key) = wallet_core
+    let signable = detect_signable(&missing, |id| {
+        wallet_core
             .storage()
             .user_data
-            .get_pub_account_signing_key(AccountId::new(bytes))
-        {
-            signable.push((id_str.clone(), key));
-        }
-    }
+            .get_pub_account_signing_key(id)
+            .is_some()
+    })
+    .unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);
+    });
 
     if signable.is_empty() {
         eprintln!("❌ This wallet holds no key for any missing signer.");
-        process::exit(1);        
+        process::exit(1);
     }
 
     println!("This wallet can sign for:");
-    for (id, _) in &signable {
+    for id in &signable {
         println!("  {}", id);
     }
     print!("Sign and update the file? [y/N] ");
@@ -121,16 +134,22 @@ pub fn sign_command(path: &str) {
         eprintln!("❌ {}", e);
         process::exit(1);
     });
-    for (id, key) in signable {
+    for id in signable {
+        let bytes = decode_bytes_32(&id).unwrap();
+        let key = wallet_core
+            .storage()
+            .user_data
+            .get_pub_account_signing_key(AccountId::new(bytes))
+            .expect("key vanished between detection and signing");
         let signature = Signature::new(key, &message_bytes);
         let pubkey = PublicKey::new_from_private_key(key);
         blob.witnesses.insert(
-            id, 
-        WitnessEntry {
+            id,
+            WitnessEntry {
                 pubkey,
                 signature: signature.to_string(),
-            }
-        ); 
+            },
+        );
     }
 
     blob.save(path).unwrap_or_else(|e| {
@@ -160,33 +179,23 @@ pub async fn submit_command(path: &str) {
     // stale nonces, tampering, or corruption;
     blob.verify_witnesses().unwrap_or_else(|e| {
         eprintln!("❌ {}", e);
-        process::exit(1);      
+        process::exit(1);
     });
 
     let message = blob.message().unwrap_or_else(|e| {
         eprintln!("❌ {}", e);
-        process::exit(1);      
+        process::exit(1);
     });
 
     if !blob.missing_signers().is_empty() {
         eprintln!("❌ missing signers. run: spel sign <file>");
-        process::exit(1);      
+        process::exit(1);
     }
 
-    let mut witnesses_pairs: Vec<(Signature, PublicKey)>  = Vec::new();
-    for id in &blob.signers {
-        let entry = blob.witnesses.get(id).unwrap_or_else(|| {
-            eprintln!("❌ no witness for '{}'", id);
-            process::exit(1);      
-        });
-        let sig = entry.signature.parse::<Signature>().unwrap_or_else(|e| {
-            eprintln!("❌ {}", e);
-            process::exit(1);
-        });
-        witnesses_pairs.push((sig, entry.pubkey.clone()));
-    }
-
-    let witness_set = WitnessSet::from_raw_parts(witnesses_pairs);
+    let witness_set = blob.witness_set().unwrap_or_else(|e| {
+        eprintln!("❌ {}", e);
+        process::exit(1);
+    });
     let tx = PublicTransaction::new(message, witness_set);
 
     let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
@@ -207,10 +216,8 @@ pub async fn submit_command(path: &str) {
     println!("   tx_hash: {}", tx_hash);
     println!("   Waiting for confirmation...");
 
-    let poller = wallet::poller::TxPoller::new(
-        wallet_core.config(),
-        wallet_core.sequencer_client.clone(),
-    );
+    let poller =
+        wallet::poller::TxPoller::new(wallet_core.config(), wallet_core.sequencer_client.clone());
 
     match poller.poll_tx(tx_hash).await {
         Ok(_) => println!("✅ Transaction confirmed — included in a block."),
@@ -218,5 +225,36 @@ pub async fn submit_command(path: &str) {
             eprintln!("❌ Transaction NOT confirmed: {e:#}");
             process::exit(1);
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_signable_filters_by_held_keys() {
+        let held = AccountId::new([0xaa; 32]);
+        let missing = vec![
+            format!("0x{}", "aa".repeat(32)),
+            format!("0x{}", "bb".repeat(32)),
+        ];
+
+        let signable = detect_signable(&missing, |id| id == held).unwrap();
+
+        assert_eq!(signable, vec![format!("0x{}", "aa".repeat(32))]);
+    }
+
+    #[test]
+    fn detect_signable_rejects_undecodable_id() {
+        let missing = vec!["0xzz".to_string()];
+
+        let err = detect_signable(&missing, |_| true).unwrap_err();
+
+        assert!(
+            err.contains("invalid signer id"),
+            "unexpected error: {}",
+            err
+        );
     }
 }

--- a/spel-cli/src/exchange.rs
+++ b/spel-cli/src/exchange.rs
@@ -31,7 +31,7 @@ fn detect_signable(
 
 /// Load a blob, verify it, show what it is, and append witnesses for
 /// every required signer whose key the local wallet holds.
-pub fn sign_command(path: &str) {
+pub async fn sign_command(path: &str) {
     let mut blob = TxBlob::load(path).unwrap_or_else(|e| {
         eprintln!("❌ {}", e);
         process::exit(1);
@@ -100,7 +100,7 @@ pub fn sign_command(path: &str) {
     }
 
     // Keys this wallet holds for the still-missing signers.
-    let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
+    let wallet_core = WalletCore::from_env().await.unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
         eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
         process::exit(1);
@@ -203,13 +203,13 @@ pub async fn submit_command(path: &str) {
     });
     let tx = PublicTransaction::new(message, witness_set);
 
-    let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
+    let wallet_core = WalletCore::from_env().await.unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
         eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
         process::exit(1);
     });
     let tx_hash = wallet_core
-        .sequencer_client
+        .helm_owned()
         .send_transaction(LeeTransaction::Public(tx))
         .await
         .unwrap_or_else(|e| {
@@ -221,8 +221,7 @@ pub async fn submit_command(path: &str) {
     println!("   tx_hash: {}", tx_hash);
     println!("   Waiting for confirmation...");
 
-    let poller =
-        wallet::poller::TxPoller::new(wallet_core.config(), wallet_core.sequencer_client.clone());
+    let poller = wallet_core.poller_helm();
 
     match poller.poll_tx(tx_hash).await {
         Ok(_) => println!("✅ Transaction confirmed — included in a block."),

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -10,8 +10,10 @@
 //! Use `run()` for a complete CLI entry point, or import individual modules.
 
 pub mod account_inspect;
+pub mod blob;
 pub mod cli;
 pub mod config;
+pub mod exchange;
 pub mod generate_idl;
 pub mod hex;
 pub mod init;
@@ -50,6 +52,8 @@ pub async fn run() {
     let mut data_hex: Option<String> = None;
     let mut inspect_format: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
+    let mut co_signers: Vec<String> = Vec::new();
+    let mut export_path: Option<String> = None;
     let mut remaining_args: Vec<String> = vec![args[0].clone()];
     let mut used_separator = false;
     let mut i = 1;
@@ -132,9 +136,34 @@ pub async fn run() {
                     extra_bins.insert(format!("{}-program-id", name), args[i].clone());
                 }
             },
+            "--co-signer" => {
+                i += 1;
+                if i >= args.len() || args[i].starts_with('-') {
+                    eprintln!("❌ --co-signer requires an account id");
+                    process::exit(1);
+                }
+                co_signers.push(args[i].clone());
+            },
+            "--export" => {
+                i += 1;
+                if i >= args.len() || args[i].starts_with('-') {
+                    eprintln!("❌ --export requires a file path");
+                    process::exit(1);
+                }
+                if export_path.is_some() {
+                    eprintln!("❌ --export given twice");
+                    process::exit(1);
+                }
+                export_path = Some(args[i].clone());
+            },
             _ => remaining_args.push(args[i].clone()),
         }
         i += 1;
+    }
+
+    if export_path.is_some() && dry_run.is_some() {
+        eprintln!("❌ --export and --dry-run cannot be combined");
+        process::exit(1);
     }
 
     // Load spel.toml config
@@ -389,6 +418,22 @@ pub async fn run() {
                 compute_pda_raw(&raw_args);
                 return;
             },
+            "sign" => {
+                let path = remaining_args.get(2).unwrap_or_else(|| {
+                    eprintln!("Usage: {} sign <blob-file>", args[0]);
+                    process::exit(1);
+                });
+                exchange::sign_command(path);
+                return;
+            },
+            "submit" => {
+                let path = remaining_args.get(2).unwrap_or_else(|| {
+                    eprintln!("Usage: {} submit <blob-file>", args[0]);
+                    process::exit(1);
+                });
+                exchange::submit_command(path).await;
+                return;
+            },
             _ => {},
         }
     }
@@ -487,6 +532,8 @@ pub async fn run() {
                         program_id_hex.as_deref(),
                         dry_run,
                         &extra_bins,
+                        &co_signers,
+                        export_path.as_deref(),
                     )
                     .await;
                 },

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -423,7 +423,7 @@ pub async fn run() {
                     eprintln!("Usage: {} sign <blob-file>", args[0]);
                     process::exit(1);
                 });
-                exchange::sign_command(path);
+                exchange::sign_command(path).await;
                 return;
             },
             "submit" => {

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -1,5 +1,6 @@
 //! Transaction building and submission.
 
+use crate::blob::{TxBlob, WitnessEntry};
 use crate::cli::{snake_to_kebab, to_pascal_case};
 use crate::hex::{decode_bytes_32, hex_encode, parse_account_id};
 use crate::parse::{parse_string_vec, parse_value, ParsedValue};
@@ -9,12 +10,14 @@ use common::transaction::LeeTransaction;
 use hex;
 use nssa::program::Program;
 use nssa::public_transaction::{Message, WitnessSet};
+use nssa::{PublicKey, Signature};
 use nssa::{AccountId, PublicTransaction};
 use nssa_core::account::Nonce;
 use nssa_core::program::ProgramId;
 use sequencer_service_rpc::RpcClient as _;
 use serde_json::{json, Value};
 use spel_framework_core::idl::{IdlInstruction, IdlSeed, IdlType, SpelIdl};
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fs;
 use std::process;
@@ -72,6 +75,8 @@ pub async fn execute_instruction(
     program_id_hex: Option<&str>,
     dry_run: Option<DryRunFormat>,
     extra_bins: &HashMap<String, String>,
+    co_signers: &[String],
+    export: Option<&str>,
 ) {
     // In JSON dry-run mode, suppress all human-readable preamble — only emit JSON to stdout.
     let json_mode = dry_run == Some(DryRunFormat::Json);
@@ -346,7 +351,12 @@ pub async fn execute_instruction(
         };
         match fmt {
             DryRunFormat::Json => print_dry_run_json(&summary),
-            DryRunFormat::Text => print_dry_run_text(&summary),
+            DryRunFormat::Text => {
+                println!("=== Dry Run ===");
+                print!("{}", render_dry_run_text(&summary));
+                println!("================");
+                println!("Dry run complete — not submitted.");
+            },
         }
         return;
     }
@@ -409,7 +419,11 @@ pub async fn execute_instruction(
     say!("");
 
     // ─── Transaction submission ─────────────────────────────────
-    say!("📤 Submitting transaction...");
+    if export.is_some() {
+        say!("📦 Building partial transaction for export...");
+    } else {
+        say!("📤 Submitting transaction...");
+    }
 
     let wallet_core = WalletCore::from_env().await.unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
@@ -529,12 +543,23 @@ pub async fn execute_instruction(
             }
         }
 
-        let signer_accounts: Vec<AccountId> = ix
+        let mut signer_accounts: Vec<AccountId> = ix
             .accounts
             .iter()
             .filter(|a| a.signer)
             .map(|a| *account_map.get(&a.name).unwrap())
             .collect();
+
+        for co_signer in co_signers {
+            let bytes = decode_bytes_32(co_signer).unwrap_or_else(|e| {
+                eprintln!("❌ --co-signer '{}': {}", co_signer, e);
+                process::exit(1);
+            });
+            let account_id = AccountId::new(bytes);
+            if !signer_accounts.contains(&account_id) {
+                signer_accounts.push(account_id);
+            }
+        }
 
         let nonces = if signer_accounts.is_empty() {
             vec![]
@@ -548,6 +573,100 @@ pub async fn execute_instruction(
                 })
         };
 
+        let message = Message::new_preserialized(program_id, account_ids, nonces, instruction_data);
+        
+        if let Some(export_path) = export {
+            // (1) the exact bytes every signer signs
+            let message_bytes = borsh::to_vec(&message).unwrap_or_else(|e| {
+                eprintln!("❌ Failed to serialize message: {:?}", e);
+                process::exit(1);
+            });
+
+            // (2) render the summary from the built data, same renderer as --dry-run
+            let signer_names: Vec<&str> = ix
+                .accounts
+                .iter()
+                .filter(|a| a.signer)
+                .map(|a| a.name.as_str())
+                .collect();
+            let co_signer_labels: Vec<String> = signer_accounts[signer_names.len()..]
+                .iter()
+                .map(|id| format!("co-signer 0x{}", hex_encode(id.value())))
+                .collect();
+            let all_signer_names: Vec<&str> = signer_names
+                .iter()
+                .copied()
+                .chain(co_signer_labels.iter().map(|s| s.as_str()))
+                .collect();
+            let signer_nonces: Vec<Option<Nonce>> = message.nonces.iter().copied().map(Some).collect();
+            let summary_data = DryRunSummary {
+                program_id_hex: &program_id_hex_str,
+                ix,
+                account_map: &account_map,
+                parsed_account_ids: &parsed_accounts
+                    .iter()
+                    .map(|(n, b, _)| (*n, b.as_slice()))
+                    .collect::<Vec<_>>(),
+                rest_account_ids: &rest_accounts
+                    .iter()
+                    .map(|(n, es)| (*n, es.iter().map(|(b, _)| b.as_slice()).collect::<Vec<_>>()))
+                    .collect::<Vec<_>>(),
+                parsed_args: &parsed_args,
+                instruction_data: &message.instruction_data,
+                signer_names: &all_signer_names,
+                signer_nonces: &signer_nonces,
+            };
+            let summary = render_dry_run_text(&summary_data);
+
+            // (3) sign with every required key this wallet holds, skip the rest
+            let mut witnesses = BTreeMap::new();
+            for account_id in &signer_accounts {
+                if let Some(key) = wallet_core
+                    .storage()
+                    .user_data
+                    .get_pub_account_signing_key(*account_id)
+                {
+                    let signature = Signature::new(key, &message_bytes);
+                    let pubkey = PublicKey::new_from_private_key(key);
+                    witnesses.insert(
+                        format!("0x{}", hex_encode(account_id.value())),
+                        WitnessEntry {
+                            pubkey,
+                            signature: signature.to_string(),
+                        },
+                    );
+                }
+            }
+
+            // (4) assemble and write
+            let tx_blob = TxBlob {
+                version: 1,
+                summary,
+                message_hex: hex_encode(&message_bytes),
+                signers: signer_accounts
+                    .iter()
+                    .map(|id| format!("0x{}", hex_encode(id.value())))
+                    .collect(),
+                witnesses,
+            };
+            tx_blob.save(export_path).unwrap_or_else(|e| {
+                eprintln!("❌ {}", e);
+                process::exit(1);
+            });
+
+            say!("📦 Partial transaction written to {}", export_path);
+            say!(
+                "   Signed {} of {} required signers.",
+                tx_blob.witnesses.len(),
+                tx_blob.signers.len()
+            );
+            for missing in tx_blob.missing_signers() {
+                say!("   Missing: {}", missing);
+            }
+            say!("   Send the file to the remaining signers to run: spel sign <file>");
+            return;
+        }
+
         let signing_keys: Vec<_> = signer_accounts
             .iter()
             .map(|id| {
@@ -560,7 +679,6 @@ pub async fn execute_instruction(
             })
             .collect();
 
-        let message = Message::new_preserialized(program_id, account_ids, nonces, instruction_data);
         let witness_set = WitnessSet::for_message(&message, &signing_keys);
         let tx = PublicTransaction::new(message, witness_set);
 
@@ -749,12 +867,13 @@ fn print_dry_run_json(s: &DryRunSummary<'_>) {
     println!("{}", serde_json::to_string_pretty(&summary).unwrap());
 }
 
-fn print_dry_run_text(s: &DryRunSummary<'_>) {
-    println!("=== Dry Run ===");
-    println!("Program ID: {}", s.program_id_hex);
-    println!("Instruction: {}", s.ix.name);
-    println!();
-    println!("Accounts:");
+fn render_dry_run_text(s: &DryRunSummary<'_>) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    writeln!(out, "Program ID: {}", s.program_id_hex).unwrap();
+    writeln!(out, "Instruction: {}", s.ix.name).unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "Accounts:").unwrap();
     for acc in &s.ix.accounts {
         let mut flags: Vec<&str> = Vec::new();
         if acc.signer {
@@ -778,53 +897,52 @@ fn print_dry_run_text(s: &DryRunSummary<'_>) {
                 .get(&acc.name)
                 .map(|a| format!("{}", a))
                 .unwrap_or_else(|| UNRESOLVED.to_string());
-            println!("  PDA {} → {}{}", acc.name, id, flags_str);
-            println!("    seeds: {}", format_pda_seeds(&pda.seeds));
+            writeln!(out, "  PDA {} → {}{}", acc.name, id, flags_str).unwrap();
+            writeln!(out, "    seeds: {}", format_pda_seeds(&pda.seeds)).unwrap();
         } else if acc.rest {
             if let Some((_, entries)) = s.rest_account_ids.iter().find(|(n, _)| *n == acc.name) {
                 if entries.is_empty() {
-                    println!("  {} → (none — variadic rest){}", acc.name, flags_str);
+                    writeln!(out, "  {} → (none — variadic rest){}", acc.name, flags_str).unwrap();
                 } else {
                     for bytes in entries {
-                        println!("  {} → 0x{}{}", acc.name, hex_encode(bytes), flags_str);
+                        writeln!(out, "  {} → 0x{}{}", acc.name, hex_encode(bytes), flags_str).unwrap();
                     }
                 }
             }
         } else if let Some((_, b)) = s.parsed_account_ids.iter().find(|(n, _)| *n == acc.name) {
-            println!("  {} → 0x{}{}", acc.name, hex_encode(b), flags_str);
+            writeln!(out, "  {} → 0x{}{}", acc.name, hex_encode(b), flags_str).unwrap();
         } else {
             debug_assert!(
                 false,
                 "non-rest non-PDA account '{}' missing from parsed_account_ids",
                 acc.name
             );
-            println!("  {} → {}{}", acc.name, UNRESOLVED, flags_str);
+            writeln!(out, "  {} → {}{}", acc.name, UNRESOLVED, flags_str).unwrap();
         }
     }
-    println!();
-    println!("Arguments:");
+    writeln!(out).unwrap();
+    writeln!(out, "Arguments:").unwrap();
     for (name, _, val) in s.parsed_args {
-        println!("  --{} {}", snake_to_kebab(name), val);
+        writeln!(out, "  --{} {}", snake_to_kebab(name), val).unwrap();
     }
-    println!();
+    writeln!(out).unwrap();
     let ix_data_hex: String = s
         .instruction_data
         .iter()
         .flat_map(|w| w.to_le_bytes())
         .map(|b| format!("{:02x}", b))
         .collect();
-    println!("Instruction data: 0x{}", ix_data_hex);
+    writeln!(out, "Instruction data: 0x{}", ix_data_hex).unwrap();
     if !s.signer_names.is_empty() {
-        println!();
-        println!("Signers:");
+        writeln!(out).unwrap();
+        writeln!(out, "Signers:").unwrap();
         for (i, name) in s.signer_names.iter().enumerate() {
             let nonce_str = match s.signer_nonces.get(i).and_then(|n| n.as_ref()) {
                 Some(n) => format!("nonce={}", n.0),
                 None => "nonce=(unknown)".to_string(),
             };
-            println!("  {}: {}", name, nonce_str);
+            writeln!(out, "  {}: {}", name, nonce_str).unwrap();
         }
     }
-    println!("================");
-    println!("Dry run complete — not submitted.");
+    out
 }

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -619,15 +619,14 @@ pub async fn execute_instruction(
             };
             let summary = render_dry_run_text(&summary_data);
 
-            // (3) sign with every required key this wallet holds, skip the rest
+            // (3) sign with every required key this wallet holds, skip the rest.
+            // v0.2.0: witnesses sign the 32-byte message hash, matching
+            // WitnessSet::is_valid_for at submit.
+            let message_hash = message.hash();
             let mut witnesses = BTreeMap::new();
             for account_id in &signer_accounts {
-                if let Some(key) = wallet_core
-                    .storage()
-                    .user_data
-                    .get_pub_account_signing_key(*account_id)
-                {
-                    let signature = Signature::new(key, &message_bytes);
+                if let Some(key) = wallet_core.get_account_public_signing_key(*account_id) {
+                    let signature = Signature::new(key, &message_hash);
                     let pubkey = PublicKey::new_from_private_key(key);
                     witnesses.insert(
                         format!("0x{}", hex_encode(account_id.value())),

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -10,8 +10,8 @@ use common::transaction::LeeTransaction;
 use hex;
 use nssa::program::Program;
 use nssa::public_transaction::{Message, WitnessSet};
-use nssa::{PublicKey, Signature};
 use nssa::{AccountId, PublicTransaction};
+use nssa::{PublicKey, Signature};
 use nssa_core::account::Nonce;
 use nssa_core::program::ProgramId;
 use sequencer_service_rpc::RpcClient as _;
@@ -574,7 +574,7 @@ pub async fn execute_instruction(
         };
 
         let message = Message::new_preserialized(program_id, account_ids, nonces, instruction_data);
-        
+
         if let Some(export_path) = export {
             // (1) the exact bytes every signer signs
             let message_bytes = borsh::to_vec(&message).unwrap_or_else(|e| {
@@ -598,7 +598,8 @@ pub async fn execute_instruction(
                 .copied()
                 .chain(co_signer_labels.iter().map(|s| s.as_str()))
                 .collect();
-            let signer_nonces: Vec<Option<Nonce>> = message.nonces.iter().copied().map(Some).collect();
+            let signer_nonces: Vec<Option<Nonce>> =
+                message.nonces.iter().copied().map(Some).collect();
             let summary_data = DryRunSummary {
                 program_id_hex: &program_id_hex_str,
                 ix,
@@ -905,7 +906,8 @@ fn render_dry_run_text(s: &DryRunSummary<'_>) -> String {
                     writeln!(out, "  {} → (none — variadic rest){}", acc.name, flags_str).unwrap();
                 } else {
                     for bytes in entries {
-                        writeln!(out, "  {} → 0x{}{}", acc.name, hex_encode(bytes), flags_str).unwrap();
+                        writeln!(out, "  {} → 0x{}{}", acc.name, hex_encode(bytes), flags_str)
+                            .unwrap();
                     }
                 }
             }

--- a/spel-cli/tests/cli_args.rs
+++ b/spel-cli/tests/cli_args.rs
@@ -1,0 +1,79 @@
+//! Argument-parsing regression tests against the real binary.
+
+use std::process::Command;
+
+fn spel(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_spel"))
+        .args(args)
+        .output()
+        .expect("failed to run spel binary")
+}
+
+fn stderr_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn export_as_last_token_errors_cleanly() {
+    let out = spel(&["--export"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("--export requires"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[test]
+fn co_signer_without_value_errors() {
+    // Shape 1: flag is the last token, nothing after it.
+    let out = spel(&["--co-signer"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("--co-signer requires an account id"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+
+    // Shape 2: next token is another flag, not a value.
+    let out = spel(&["--co-signer", "--dry-run"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("--co-signer requires an account id"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[test]
+fn export_twice_errors() {
+    let out = spel(&["--export", "a.json", "--export", "b.json"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("export given twice"),
+        "stderr: {}",
+        stderr_of(&out)
+    )
+}
+
+#[test]
+fn export_conflicts_with_dry_run() {
+    let out = spel(&["--export", "a.json", "--dry-run"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("--export and --dry-run cannot be combined"),
+        "stderr: {}",
+        stderr_of(&out)
+    )
+}
+
+#[test]
+fn dry_run_conflicts_with_export() {
+    let out = spel(&["--dry-run", "--export", "a.json"]);
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("--export and --dry-run cannot be combined"),
+        "stderr: {}",
+        stderr_of(&out)
+    )
+}

--- a/spel-cli/tests/cli_args.rs
+++ b/spel-cli/tests/cli_args.rs
@@ -77,3 +77,85 @@ fn dry_run_conflicts_with_export() {
         stderr_of(&out)
     )
 }
+
+/// Minimal one-instruction IDL for exercising instruction-arg parsing.
+fn write_fixture_idl(dir: &std::path::Path) -> std::path::PathBuf {
+    let idl = serde_json::json!({
+        "version": "0.1.0",
+        "name": "fixture",
+        "instructions": [{
+            "name": "do_thing",
+            "accounts": [{ "name": "caller", "signer": true }],
+            "args": [{ "name": "new_value", "type": "u64" }]
+        }]
+    });
+    let path = dir.join("fixture-idl.json");
+    std::fs::write(&path, serde_json::to_vec_pretty(&idl).unwrap()).unwrap();
+    path
+}
+
+// Live-round regression (2026-08-09): --export placed after the '--'
+// separator was silently dropped and the transaction submitted to the
+// sequencer instead of being written to the blob file.
+#[test]
+fn misplaced_export_refuses_before_building_a_transaction() {
+    let dir = tempfile::tempdir().unwrap();
+    let idl = write_fixture_idl(dir.path());
+    let blob = dir.path().join("never-written.json");
+
+    let out = spel(&[
+        "--idl",
+        idl.to_str().unwrap(),
+        "--program",
+        &"ab".repeat(32),
+        "--",
+        "do-thing",
+        "--new-value",
+        "7",
+        "--caller",
+        &"11".repeat(32),
+        "--export",
+        blob.to_str().unwrap(),
+    ]);
+
+    assert!(!out.status.success(), "misplaced --export must refuse");
+    let err = stderr_of(&out);
+    assert!(
+        err.contains("--export: unknown argument"),
+        "stderr names the flag: {err}"
+    );
+    assert!(
+        err.contains("before the '--' separator"),
+        "stderr points at the fix: {err}"
+    );
+    assert!(!blob.exists(), "no blob may be written on refusal");
+}
+
+// Control: the same invocation with the flag in its global position
+// parses and reaches transaction building (--dry-run, no network).
+#[test]
+fn well_placed_args_still_parse() {
+    let dir = tempfile::tempdir().unwrap();
+    let idl = write_fixture_idl(dir.path());
+
+    let out = spel(&[
+        "--idl",
+        idl.to_str().unwrap(),
+        "--program",
+        &"ab".repeat(32),
+        "--dry-run",
+        "--",
+        "do-thing",
+        "--new-value",
+        "7",
+        "--caller",
+        &"11".repeat(32),
+    ]);
+
+    let err = stderr_of(&out);
+    assert!(
+        out.status.success(),
+        "dry-run with legal args must pass, stderr: {err}"
+    );
+    assert!(!err.contains("unknown argument"), "stderr: {err}");
+}

--- a/spel-cli/tests/sign_prompt.rs
+++ b/spel-cli/tests/sign_prompt.rs
@@ -1,0 +1,70 @@
+//! The co-signer prompt, exercised through the real binary. A fully
+//! signed blob makes `spel sign` print the decoded section and return
+//! before touching any wallet, so the output is deterministic.
+
+use std::collections::BTreeMap;
+use std::process::Command;
+
+use nssa::public_transaction::Message;
+use nssa::{AccountId, PrivateKey, PublicKey, Signature};
+use spel::blob::{TxBlob, WitnessEntry};
+use spel::hex::hex_encode;
+
+#[test]
+fn sign_prompt_decodes_operative_content_from_the_bytes() {
+    let key = PrivateKey::try_new([1; 32]).unwrap();
+    let pubkey = PublicKey::new_from_private_key(&key);
+    let account_id = AccountId::from(&pubkey);
+    let message = Message::try_new(
+        [0; 8],
+        vec![account_id],
+        vec![1_u128.into()],
+        vec![1, 2, 3, 4],
+    )
+    .unwrap();
+    let bytes = borsh::to_vec(&message).unwrap();
+
+    let id = format!("0x{}", hex_encode(account_id.value()));
+    let signature = Signature::new(&key, &message.hash());
+    let mut witnesses = BTreeMap::new();
+    witnesses.insert(
+        id.clone(),
+        WitnessEntry {
+            pubkey,
+            signature: signature.to_string(),
+        },
+    );
+    let blob = TxBlob {
+        version: 1,
+        summary: "benign-looking summary".to_string(),
+        message_hex: hex_encode(&bytes),
+        signers: vec![id],
+        witnesses,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("blob.json");
+    blob.save(path.to_str().unwrap()).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_spel"))
+        .arg("sign")
+        .arg(&path)
+        .output()
+        .expect("run spel sign");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "sign must exit clean on a fully signed blob:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("=== Decoded from message bytes ==="),
+        "prompt lost its decode section:\n{stdout}"
+    );
+    // The payload bytes 1,2,3,4 travel risc0-encoded, a length word then
+    // one word per byte. The prompt renders the field exactly as the
+    // capture writer does.
+    assert!(
+        stdout.contains("Instruction data: 0x0400000001000000020000000300000004000000"),
+        "prompt must show the instruction data bytes:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Description

Some instructions need signatures from accounts whose keys live on different machines. A transaction's authorization per account is derived from the witness set over the message, not from the `#[account(signer)]` annotation alone, and [admin-authority](https://github.com/mmlado/spel-admin-authority)'s `admin_transfer` with a `Signer` candidate is the first concrete case: the current admin and the new admin must both sign one message. The CLI could only sign with locally held keys.

This PR adds an offline partial-transaction flow. The exporting machine builds and signs the transaction and writes it to a file instead of submitting. The file travels to each co-signer over any channel, they inspect and sign it, and anyone submits once all witnesses are collected.

The file format is a thin JSON envelope over borsh nssa types, documented in `spel-cli/src/blob.rs`. Any tool can produce or consume it. The signers list is the order contract: it matches the nonce order inside the message and dictates witness order at submit. Verification checks each signature over the stored message bytes and checks that each pubkey derives the claimed account id.

Verified live on a local LEZ v0.1.2 stack with two wallets: export by one, sign by the other, submit passed signature and nonce validation and failed only at the expected Unknown program for an undeployed program id.

Related issues:

- #239 is the declaration half of the same problem: IDL metadata for conditional signers. This PR is the transport half. With #239 metadata the `--co-signer` flag could later be derived from the IDL and the instruction arguments.
- #234: while testing this feature against a local v0.1.2 stack, spel-built public transactions passed signature validation. The InvalidSignature rejection did not reproduce locally, see comment on the issue.

Known limits, deliberate for v1: co-signers decide based on the embedded summary (trust model documented in blob.rs, independent IDL decode of the message bytes is the planned upgrade). `--dry-run` does not show co-signers. `--export` supports public transactions only.

## Changes

- `spel-cli/src/blob.rs` (new): partial-transaction file format v1 with load/save, verification, and witness set assembly in signers order
- `--co-signer <id>` (repeatable) and `--export <file>` flags: build the message once with nonces for all signers, sign with wallet-held keys, write the file instead of submitting
- `spel sign <file>` (new subcommand): verify collected witnesses, show the embedded summary next to fields decoded locally from the message bytes, confirm, sign for wallet-held keys, write back. Works offline
- `spel submit <file>` (new subcommand): completeness check, witness set assembly in signers order, submit through the existing sequencer client
- Dry-run text renderer refactored to return a string so the export path embeds the same summary a dry run prints
- Tests: format roundtrip, witness order assembly (constructed so map iteration order disagrees with signers order), stale and tampered blob rejection, sign auto-detection, and binary tests for the argument parsing
- README: multi-signature transactions section under CLI usage

## Checklist

- [x] Builds cleanly
- [x] Tests pass (95: 89 lib, 5 binary arg tests, 1 doc test)
- [x] README updated if new features, CLI commands, or behaviour changed
- [x] New public methods have doc comments
- [x] Branch is off `main` (not another feature branch)