### PR TITLE
feat: migrate SPEL to LEZ v0.2.4 - WalletCore async API + ViewingPublicKey PDA derivation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "unit"
@@ -29,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "e2e"
@@ -58,6 +62,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
@@ -166,6 +172,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Clone LEZ at correct revision
         run: |
@@ -251,6 +259,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Clone LEZ at correct revision
         run: |
@@ -336,6 +346,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Clone LEZ at correct revision
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           toolchain: 1.88.0
           components: clippy
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
       - uses: Swatinem/rust-cache@v2
       - name: cargo clippy
         # spel and spel-ffi-compile-test have transitive deps (logos-blockchain-poq,
@@ -55,6 +57,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.88.0
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
       - uses: Swatinem/rust-cache@v2
       - name: cargo test
         # spel and spel-ffi-compile-test excluded for same transitive dep reason as clippy job above.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,15 +40,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "aes-gcm"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
+ "aead 0.5.2",
+ "aes 0.8.4",
  "cipher 0.4.4",
- "ctr",
+ "ctr 0.9.2",
  "ghash",
  "subtle",
 ]
@@ -73,7 +94,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amm_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "borsh",
  "lee_core",
@@ -186,7 +207,7 @@ dependencies = [
  "digest 0.10.7",
  "fnv",
  "merlin",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -396,7 +417,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -435,7 +456,7 @@ checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 [[package]]
 name = "associated_token_account_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "lee_core",
  "risc0-zkvm",
@@ -584,7 +605,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http 1.4.0",
  "log",
  "url",
@@ -593,7 +614,7 @@ dependencies = [
 [[package]]
 name = "authenticated_transfer_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "serde",
 ]
@@ -680,6 +701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +721,12 @@ name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -788,6 +821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bonsai-sdk"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,9 +869,10 @@ dependencies = [
 [[package]]
 name = "bridge_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "lee_core",
+ "risc0-zkvm",
  "serde",
 ]
 
@@ -845,7 +888,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -934,6 +977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +993,18 @@ checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7415d7ee93607d3cea8e980aa5f250b0d63564c770e87c0e0cabafd063df98"
+dependencies = [
+ "aead 0.6.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1057,7 +1121,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1097,11 +1161,11 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "anyhow",
  "authenticated_transfer_core",
- "base64",
+ "base64 0.22.1",
  "borsh",
  "clock_core",
  "hex",
@@ -1112,7 +1176,7 @@ dependencies = [
  "programs",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "system_accounts",
  "thiserror 2.0.18",
 ]
@@ -1224,6 +1288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1363,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,12 +1410,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1484,7 +1580,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1590,7 +1686,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1679,11 +1777,26 @@ checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "serdect 0.2.0",
+ "signature 2.2.0",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0-rc.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
+dependencies = [
+ "der 0.8.0",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.0",
+ "rfc6979 0.6.0-pre.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1694,7 +1807,7 @@ checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
  "serde",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1707,7 +1820,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1742,17 +1855,38 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array 0.14.7",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.3",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3273f1195b6f6253ebda493d6742c8baa9b26a291674cd96d92a0f09e90e9b46"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1885,7 +2019,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 [[package]]
 name = "faucet_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "lee_core",
  "serde",
@@ -1909,6 +2043,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2246,8 +2390,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2412,7 +2567,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2422,6 +2586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2520,7 +2693,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2581,7 +2756,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2870,6 +3045,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding",
  "hybrid-array",
 ]
 
@@ -3058,7 +3234,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
@@ -3109,7 +3285,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -3184,12 +3360,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
- "sha2",
- "signature",
+ "serdect 0.2.0",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "k256"
+version = "0.14.0-rc.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905d38bdbb43bb506efa0a428b3e969ff244549832a86b18591492f503adfe37"
+dependencies = [
+ "cpubits",
+ "ecdsa 0.17.0-rc.22",
+ "elliptic-curve 0.14.0",
+ "primeorder",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -3224,7 +3415,7 @@ dependencies = [
 [[package]]
 name = "key_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3233,26 +3424,54 @@ dependencies = [
  "hex",
  "hmac-sha512",
  "itertools 0.14.0",
- "k256",
+ "k256 0.13.4",
  "lee",
  "lee_core",
  "ml-kem",
  "rand 0.8.6",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "keycard-rs"
+version = "0.1.0"
+source = "git+https://github.com/keycard-tech/keycard-rs?rev=9535a657ba04b1e6916de51777e22b4837c1a84d#9535a657ba04b1e6916de51777e22b4837c1a84d"
+dependencies = [
+ "aes 0.9.2",
+ "base64 0.21.7",
+ "cbc",
+ "ccm",
+ "generic-array 0.14.7",
+ "getrandom 0.2.17",
+ "getrandom 0.4.2",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "k256 0.14.0-rc.14",
+ "pbkdf2",
+ "pcsc",
+ "rand_core 0.6.4",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "thiserror 1.0.69",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
 name = "keycard_wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
+ "bip39",
+ "hex",
+ "keycard-rs",
  "lee",
  "log",
- "pyo3",
- "serde",
- "serde_json",
+ "pcsc",
+ "rand 0.8.6",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -3297,13 +3516,13 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "anyhow",
  "borsh",
  "build_utils",
  "hex",
- "k256",
+ "k256 0.13.4",
  "lee_core",
  "log",
  "rand 0.8.6",
@@ -3311,14 +3530,14 @@ dependencies = [
  "risc0-zkvm",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "base58",
  "borsh",
@@ -3472,7 +3691,7 @@ checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "either",
@@ -3491,7 +3710,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "web-time",
 ]
@@ -3526,13 +3745,13 @@ dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
- "hkdf",
- "k256",
+ "hkdf 0.12.4",
+ "k256 0.13.4",
  "multihash",
  "quick-protobuf",
  "rand 0.8.6",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tracing",
  "zeroize",
@@ -3558,7 +3777,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.6",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
@@ -3790,9 +4009,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "logos-blockchain-blake2btree"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
+dependencies = [
+ "blake2",
+ "logos-blockchain-dynamic-merkle",
+ "logos-blockchain-merkle-tree",
+]
+
+[[package]]
 name = "logos-blockchain-blend-crypto"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "blake2",
  "logos-blockchain-groth16",
@@ -3805,8 +4034,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-message"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "blake2",
  "derivative",
@@ -3814,6 +4043,7 @@ dependencies = [
  "itertools 0.14.0",
  "logos-blockchain-blend-crypto",
  "logos-blockchain-blend-proofs",
+ "logos-blockchain-codec",
  "logos-blockchain-core",
  "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-groth16",
@@ -3829,13 +4059,14 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-proofs"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
  "hex",
  "logos-blockchain-blend-crypto",
+ "logos-blockchain-codec",
  "logos-blockchain-groth16",
  "logos-blockchain-pol",
  "logos-blockchain-poq",
@@ -3849,8 +4080,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-broadcast-service"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "derivative",
@@ -3863,8 +4094,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-service"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3944,8 +4175,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-circuits-prover"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "rust-rapidsnark",
 ]
@@ -3970,9 +4201,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-blockchain-codec"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
+dependencies = [
+ "hex",
+ "logos-blockchain-codec-macros",
+ "logos-blockchain-groth16",
+ "logos-blockchain-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "logos-blockchain-codec-macros"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
+dependencies = [
+ "hex",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "logos-blockchain-common-http-client"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "futures",
  "hex",
@@ -3994,17 +4248,18 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-core"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "ark-ff",
  "bincode",
  "blake2",
  "bytes",
  "const-hex",
- "futures",
  "hex",
+ "logos-blockchain-blake2btree",
  "logos-blockchain-blend-proofs",
+ "logos-blockchain-codec",
  "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-groth16",
  "logos-blockchain-key-management-system-keys",
@@ -4016,9 +4271,7 @@ dependencies = [
  "logos-blockchain-utils",
  "logos-blockchain-utxotree",
  "multiaddr",
- "nom 8.0.0",
  "num-bigint",
- "rpds",
  "serde",
  "strum",
  "thiserror 2.0.18",
@@ -4028,11 +4281,13 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-cryptarchia-engine"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
+ "logos-blockchain-codec",
  "logos-blockchain-pol",
  "logos-blockchain-utils",
+ "rpds",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -4043,8 +4298,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-cryptarchia-sync"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "bytes",
  "futures",
@@ -4061,9 +4316,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-blockchain-dynamic-merkle"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
+dependencies = [
+ "rpds",
+ "serde",
+]
+
+[[package]]
 name = "logos-blockchain-groth16"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4073,6 +4337,7 @@ dependencies = [
  "generic-array 1.4.1",
  "hex",
  "num-bigint",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4080,8 +4345,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-http-api-common"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "axum",
  "logos-blockchain-core",
@@ -4101,14 +4366,15 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-keys"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "bytes",
  "ed25519-dalek",
  "generic-array 1.4.1",
  "hex",
+ "logos-blockchain-codec",
  "logos-blockchain-groth16",
  "logos-blockchain-key-management-system-macros",
  "logos-blockchain-log-targets",
@@ -4128,8 +4394,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-macros"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4138,8 +4404,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-ledger"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "derivative",
  "logos-blockchain-blend-crypto",
@@ -4164,8 +4430,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-libp2p"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "backon",
@@ -4193,16 +4459,16 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-log-targets"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "logos-blockchain-log-targets-macros",
 ]
 
 [[package]]
 name = "logos-blockchain-log-targets-macros"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4210,13 +4476,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-blockchain-merkle-tree"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
+dependencies = [
+ "logos-blockchain-dynamic-merkle",
+ "rpds",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "logos-blockchain-mmr"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "ark-ff",
  "logos-blockchain-groth16",
  "logos-blockchain-poseidon2",
+ "logos-blockchain-utils",
  "rpds",
  "serde",
  "thiserror 2.0.18",
@@ -4224,8 +4502,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-network-service"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "futures",
@@ -4234,6 +4512,7 @@ dependencies = [
  "logos-blockchain-libp2p",
  "logos-blockchain-log-targets",
  "logos-blockchain-tracing",
+ "logos-blockchain-utils",
  "overwatch",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
@@ -4245,8 +4524,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poc"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "logos-blockchain-circuits-poc-sys",
  "logos-blockchain-circuits-prover",
@@ -4262,8 +4541,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-pol"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "astro-float",
  "logos-blockchain-circuits-pol-sys",
@@ -4282,8 +4561,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poq"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "logos-blockchain-circuits-poq-sys",
  "logos-blockchain-circuits-prover",
@@ -4301,8 +4580,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poseidon2"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -4312,8 +4591,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-proofs-error"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "logos-blockchain-circuits-types",
  "logos-blockchain-groth16",
@@ -4323,24 +4602,24 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-services-utils"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
+ "bytes",
  "futures",
  "log",
  "logos-blockchain-log-targets",
  "overwatch",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-storage-service"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4348,7 +4627,9 @@ dependencies = [
  "logos-blockchain-core",
  "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-log-targets",
+ "logos-blockchain-services-utils",
  "logos-blockchain-tracing",
+ "logos-blockchain-utils",
  "overwatch",
  "serde",
  "thiserror 2.0.18",
@@ -4358,8 +4639,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-time-service"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "futures",
@@ -4381,8 +4662,8 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tracing"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "flate2",
  "logos-blockchain-log-targets",
@@ -4407,15 +4688,17 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-utils"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "async-trait",
  "blake2",
  "cipher 0.4.4",
  "const-hex",
+ "futures",
  "humantime",
  "logos-blockchain-log-targets",
+ "multiaddr",
  "overwatch",
  "rand 0.8.6",
  "serde",
@@ -4424,27 +4707,27 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "time",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-utxotree"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "ark-ff",
- "logos-blockchain-groth16",
+ "logos-blockchain-dynamic-merkle",
+ "logos-blockchain-merkle-tree",
  "logos-blockchain-poseidon2",
- "num-bigint",
  "rpds",
  "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "logos-blockchain-zksign"
-version = "0.1.2"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+version = "0.0.0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=e2a1c3b7ef2191c224f998b94332c5926c789f9d#e2a1c3b7ef2191c224f998b94332c5926c789f9d"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-signature-sys",
@@ -4455,6 +4738,7 @@ dependencies = [
  "logos-blockchain-proofs-error",
  "num-bigint",
  "serde",
+ "serde-big-array",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
@@ -4492,6 +4776,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -4843,15 +5150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5097,7 +5395,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "overwatch"
 version = "0.1.0"
-source = "git+https://github.com/logos-co/Overwatch?rev=448c192#448c192895b8311c742b1726a1bb12ee314ad95c"
+source = "git+https://github.com/logos-co/Overwatch?rev=ae887f41f5a626c341179026ad7f03953ff2072e#ae887f41f5a626c341179026ad7f03953ff2072e"
 dependencies = [
  "async-trait",
  "futures",
@@ -5112,10 +5410,10 @@ dependencies = [
 [[package]]
 name = "overwatch-derive"
 version = "0.1.0"
-source = "git+https://github.com/logos-co/Overwatch?rev=448c192#448c192895b8311c742b1726a1bb12ee314ad95c"
+source = "git+https://github.com/logos-co/Overwatch?rev=ae887f41f5a626c341179026ad7f03953ff2072e#ae887f41f5a626c341179026ad7f03953ff2072e"
 dependencies = [
  "convert_case 0.8.0",
- "proc-macro-error2",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5157,12 +5455,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
+dependencies = [
+ "bitflags 2.11.1",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ef017e15d2e5592a9e39a346c1dbaea5120bab7ed7106b210ef58ebd97003"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -5237,6 +5564,12 @@ dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polling"
@@ -5336,6 +5669,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-rc.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
+dependencies = [
+ "elliptic-curve 0.14.0",
+ "once_cell",
+ "primefield",
+ "serdect 0.4.3",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,6 +5750,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5414,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "programs"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "build_utils",
  "lee",
@@ -5510,63 +5880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost 0.13.5",
-]
-
-[[package]]
-name = "pyo3"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
-dependencies = [
- "libc",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5830,7 +6143,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -5879,8 +6192,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
+dependencies = [
+ "ctutils",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -6054,7 +6377,7 @@ dependencies = [
  "risc0-core",
  "risc0-zkvm-platform",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "stability",
  "tracing",
 ]
@@ -6089,7 +6412,7 @@ dependencies = [
  "rzup",
  "semver",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "stability",
  "tempfile",
  "tracing",
@@ -6176,7 +6499,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
+ "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
  "zeroize",
@@ -6265,7 +6588,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -6390,7 +6713,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "strum",
  "tempfile",
  "thiserror 2.0.18",
@@ -6452,11 +6775,25 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array 0.14.7",
  "pkcs8 0.10.2",
- "serdect",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -6503,7 +6840,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sequencer_service_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "common",
  "hex",
@@ -6515,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "sequencer_service_rpc"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "jsonrpsee",
  "sequencer_service_protocol",
@@ -6529,6 +6866,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6621,7 +6967,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -6666,7 +7012,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -6693,6 +7049,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6710,6 +7077,17 @@ checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
  "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -6745,6 +7123,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6807,7 +7195,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "httparse",
@@ -6860,7 +7248,7 @@ dependencies = [
  "sequencer_service_rpc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "spel-client-gen",
  "spel-framework-core",
  "tokio",
@@ -6891,7 +7279,7 @@ dependencies = [
  "proc-macro2",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "thiserror 1.0.69",
  "toml",
@@ -6904,7 +7292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "spel-framework-core",
  "syn 2.0.117",
 ]
@@ -6934,6 +7322,12 @@ dependencies = [
  "base64ct",
  "der 0.8.0",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "spongefish"
@@ -7091,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "system_accounts"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "bridge_core",
  "clock_core",
@@ -7118,12 +7512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7139,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "testnet_initial_state"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "key_protocol",
  "lee",
@@ -7266,7 +7654,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "borsh",
  "lee_core",
@@ -7415,7 +7803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http 1.4.0",
  "http-body",
@@ -7767,7 +8155,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -7784,7 +8172,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http 1.4.0",
  "httparse",
  "log",
@@ -7895,7 +8283,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "lee_core",
  "risc0-zkvm",
@@ -7921,7 +8309,7 @@ dependencies = [
 [[package]]
 name = "wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "amm_core",
  "anyhow",
@@ -7948,13 +8336,12 @@ dependencies = [
  "log",
  "optfield",
  "programs",
- "pyo3",
  "rand 0.8.6",
  "rpassword",
  "sequencer_service_rpc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "system_accounts",
  "testnet_initial_state",
  "thiserror 2.0.18",
@@ -8649,6 +9036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86421f2a70c9e6cab8d84c99fb62d8761d355bd1285443a7e7ccad15aa515f2"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8676,7 +9074,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -14,11 +14,11 @@ spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] 
 # signing (spel/co issue #234) and the wallet storage schema written by the wallet
 # CLI (#235). nssa_core/nssa were renamed to lee_core/lee upstream — aliased back
 # via `package` so spel's source keeps compiling.
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee_core", features = ["host"] }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", features = ["client"] }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-cli/src/account_inspect.rs
+++ b/spel-cli/src/account_inspect.rs
@@ -63,7 +63,7 @@ pub async fn inspect_account(
 }
 
 async fn fetch_account_data(account_id: nssa::AccountId) -> Vec<u8> {
-    let wallet_core = wallet::WalletCore::from_env().unwrap_or_else(|e| {
+    let wallet_core = wallet::WalletCore::from_env().await.unwrap_or_else(|e| {
         eprintln!("Failed to initialize wallet: {:?}", e);
         eprintln!("Set LEE_WALLET_HOME_DIR or use --data <hex>");
         process::exit(1);

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -101,7 +101,7 @@ ui/
     let lez_ref_ffi = match (lez_tag, lez_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
         (_, Some(r)) => format!("rev = \"{}\"", r),
-        _ => "tag = \"v0.2.0\"".to_string(),
+        _ => "tag = \"v0.2.4\"".to_string(),
     };
     let spel_ref_ffi = match (spel_tag, spel_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
@@ -692,7 +692,7 @@ risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
     let lez_ref = match (lez_tag, lez_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
         (_, Some(r)) => format!("rev = \"{}\"", r),
-        _ => "tag = \"v0.2.0\"".to_string(),
+        _ => "tag = \"v0.2.4\"".to_string(),
     };
     let spel_ref = match (spel_tag, spel_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -564,6 +564,7 @@ fn compute_pda_command(
     // --npk <64-char-hex> is reserved for private PDA derivation and not treated as a seed arg.
     let mut seed_args: HashMap<String, ParsedValue> = HashMap::new();
     let mut npk_hex: Option<String> = None;
+    let mut vpk_hex: Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         if let Some(key) = args[i].strip_prefix("--") {
@@ -571,6 +572,11 @@ fn compute_pda_command(
                 let raw = &args[i + 1];
                 if key == "npk" {
                     npk_hex = Some(raw.clone());
+                    i += 2;
+                    continue;
+                }
+                if key == "vpk" {
+                    vpk_hex = Some(raw.clone());
                     i += 2;
                     continue;
                 }
@@ -637,21 +643,22 @@ fn compute_pda_command(
         process::exit(1);
     };
 
-    // For private PDAs, parse and require --npk
+    // For private PDAs, parse and require --npk and --vpk
+    use nssa_core::encryption::ViewingPublicKey;
     use nssa_core::NullifierPublicKey;
-    let npk: Option<NullifierPublicKey> = if pda_def.private {
-        match npk_hex {
+    let (npk, vpk): (Option<NullifierPublicKey>, Option<ViewingPublicKey>) = if pda_def.private {
+        let n = match npk_hex {
             Some(ref hex) => {
                 use crate::hex::decode_bytes_32;
                 let bytes = decode_bytes_32(hex).unwrap_or_else(|e| {
                     eprintln!("❌ Invalid --npk '{}': {}", hex, e);
                     process::exit(1);
                 });
-                Some(NullifierPublicKey(bytes))
+                NullifierPublicKey(bytes)
             },
             None => {
                 eprintln!(
-                    "❌ '{}' is a private PDA — pass --npk <64-char-hex>",
+                    "❌ '{}' is a private PDA — pass --npk <64-char-hex> and --vpk <2368-char-hex>",
                     account_name
                 );
                 eprintln!(
@@ -659,9 +666,33 @@ fn compute_pda_command(
                 );
                 process::exit(1);
             },
-        }
+        };
+        let v = match vpk_hex {
+            Some(ref hex) => {
+                let bytes = ::hex::decode(hex).unwrap_or_else(|e| {
+                    eprintln!("❌ Invalid --vpk hex: {}", e);
+                    process::exit(1);
+                });
+                ViewingPublicKey::from_bytes(bytes).unwrap_or_else(|e| {
+                    eprintln!(
+                        "❌ Invalid --vpk (expected {} bytes, ML-KEM-768 encapsulation key): {:?}",
+                        ViewingPublicKey::LEN,
+                        e
+                    );
+                    process::exit(1);
+                })
+            },
+            None => {
+                eprintln!(
+                    "❌ '{}' is a private PDA — pass --npk <64-char-hex> and --vpk <2368-char-hex>",
+                    account_name
+                );
+                process::exit(1);
+            },
+        };
+        (Some(n), Some(v))
     } else {
-        None
+        (None, None)
     };
 
     // Build account_map: parse --<account-name> <base58-id> for IdlSeed::Account seeds.
@@ -699,6 +730,7 @@ fn compute_pda_command(
         &account_map,
         &seed_args,
         npk.as_ref(),
+        vpk.as_ref(),
     ) {
         Ok(account_id) => {
             println!("{}", account_id);

--- a/spel-cli/src/pda.rs
+++ b/spel-cli/src/pda.rs
@@ -2,6 +2,7 @@
 
 use crate::parse::ParsedValue;
 use nssa::AccountId;
+use nssa_core::encryption::ViewingPublicKey;
 use nssa_core::program::{PdaSeed, ProgramId};
 use nssa_core::NullifierPublicKey;
 use spel_framework_core::idl::IdlSeed;
@@ -107,6 +108,7 @@ pub fn compute_pda_from_seeds(
     account_map: &HashMap<String, AccountId>,
     parsed_args: &HashMap<String, ParsedValue>,
     npk: Option<&NullifierPublicKey>,
+    vpk: Option<&ViewingPublicKey>,
 ) -> Result<AccountId, String> {
     if seeds.is_empty() {
         return Err("PDA requires at least one seed".to_string());
@@ -128,10 +130,13 @@ pub fn compute_pda_from_seeds(
 
     let pda_seed = PdaSeed::new(combined);
     if let Some(npk) = npk {
+        let vpk = vpk.ok_or_else(|| "Private PDA requires a ViewingPublicKey (vpk)".to_string())?;
         // The chain now derives private PDAs with a u128 `identifier`; spel has
         // no way to specify it yet, so default to 0 (the common case).
         // TODO: thread a `--identifier` flag through for non-zero identifiers.
-        Ok(AccountId::for_private_pda(program_id, &pda_seed, npk, 0))
+        Ok(AccountId::for_private_pda(
+            program_id, &pda_seed, npk, vpk, 0,
+        ))
     } else {
         Ok(AccountId::for_public_pda(program_id, &pda_seed))
     }
@@ -147,8 +152,14 @@ mod tests {
             value: "test_seed".to_string(),
         }];
         let program_id: ProgramId = [1u32; 8];
-        let result =
-            compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &HashMap::new(), None);
+        let result = compute_pda_from_seeds(
+            &seeds,
+            &program_id,
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            None,
+        );
         assert!(result.is_ok());
     }
 
@@ -168,7 +179,8 @@ mod tests {
             "create_key".to_string(),
             ParsedValue::ByteArray(vec![42u8; 32]),
         );
-        let result = compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &args, None);
+        let result =
+            compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &args, None, None);
         assert!(result.is_ok());
     }
 
@@ -185,7 +197,8 @@ mod tests {
         let program_id: ProgramId = [1u32; 8];
         let mut args = HashMap::new();
         args.insert("index".to_string(), ParsedValue::U64(5));
-        let result = compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &args, None);
+        let result =
+            compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &args, None, None);
         assert!(result.is_ok());
     }
 
@@ -195,8 +208,14 @@ mod tests {
             path: "missing".to_string(),
         }];
         let program_id: ProgramId = [1u32; 8];
-        let result =
-            compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &HashMap::new(), None);
+        let result = compute_pda_from_seeds(
+            &seeds,
+            &program_id,
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            None,
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("missing"));
     }
@@ -228,24 +247,33 @@ mod tests {
         let program_id: ProgramId = [2u32; 8];
         let npk = NullifierPublicKey([0xABu8; 32]);
 
+        let vpk = ViewingPublicKey::from_seed(&[0u8; 32], &[0u8; 32]);
         let private = compute_pda_from_seeds(
             &seeds,
             &program_id,
             &HashMap::new(),
             &HashMap::new(),
             Some(&npk),
+            Some(&vpk),
         )
         .unwrap();
-        let public =
-            compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &HashMap::new(), None)
-                .unwrap();
+        let public = compute_pda_from_seeds(
+            &seeds,
+            &program_id,
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .unwrap();
 
         assert_ne!(private, public, "private PDA must differ from public PDA");
 
         // Verify it matches a direct for_private_pda call with the same inputs
         let mut combined = [0u8; 32];
         combined[.."vault".len()].copy_from_slice(b"vault");
-        let expected = AccountId::for_private_pda(&program_id, &PdaSeed::new(combined), &npk, 0);
+        let expected =
+            AccountId::for_private_pda(&program_id, &PdaSeed::new(combined), &npk, &vpk, 0);
         assert_eq!(private, expected, "private PDA must match for_private_pda");
     }
 
@@ -258,12 +286,14 @@ mod tests {
         let npk1 = NullifierPublicKey([0x01u8; 32]);
         let npk2 = NullifierPublicKey([0x02u8; 32]);
 
+        let vpk = ViewingPublicKey::from_seed(&[0u8; 32], &[0u8; 32]);
         let addr1 = compute_pda_from_seeds(
             &seeds,
             &program_id,
             &HashMap::new(),
             &HashMap::new(),
             Some(&npk1),
+            Some(&vpk),
         )
         .unwrap();
         let addr2 = compute_pda_from_seeds(
@@ -272,6 +302,7 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
             Some(&npk2),
+            Some(&vpk),
         )
         .unwrap();
 
@@ -298,13 +329,21 @@ mod tests {
         let mut args = HashMap::new();
         args.insert("key".to_string(), ParsedValue::ByteArray(vec![0u8; 32]));
 
-        let multi = compute_pda_from_seeds(&seeds_multi, &program_id, &HashMap::new(), &args, None)
-            .unwrap();
+        let multi = compute_pda_from_seeds(
+            &seeds_multi,
+            &program_id,
+            &HashMap::new(),
+            &args,
+            None,
+            None,
+        )
+        .unwrap();
         let single = compute_pda_from_seeds(
             &seeds_single,
             &program_id,
             &HashMap::new(),
             &HashMap::new(),
+            None,
             None,
         )
         .unwrap();

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -300,6 +300,7 @@ pub async fn execute_instruction(
                 &account_map,
                 &parsed_arg_map,
                 None,
+                None,
             ) {
                 Ok(id) => {
                     account_map.insert(acc.name.clone(), id);
@@ -410,7 +411,7 @@ pub async fn execute_instruction(
     // ─── Transaction submission ─────────────────────────────────
     say!("📤 Submitting transaction...");
 
-    let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
+    let wallet_core = WalletCore::from_env().await.unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
         eprintln!("   Set LEE_WALLET_HOME_DIR environment variable");
         process::exit(1);
@@ -498,10 +499,7 @@ pub async fn execute_instruction(
         say!("   tx_hash: {}", hex::encode(response.0));
         say!("   Waiting for confirmation...");
 
-        let poller = wallet::poller::TxPoller::new(
-            wallet_core.config(),
-            wallet_core.sequencer_client.clone(),
-        );
+        let poller = wallet_core.poller_helm();
 
         match poller.poll_tx(response).await {
             Ok(_) => say!("✅ Transaction confirmed — included in a block."),
@@ -542,7 +540,7 @@ pub async fn execute_instruction(
             vec![]
         } else {
             wallet_core
-                .get_accounts_nonces(signer_accounts.clone())
+                .get_accounts_nonces(&signer_accounts)
                 .await
                 .unwrap_or_else(|e| {
                     eprintln!("❌ Failed to fetch nonces: {:?}", e);
@@ -567,7 +565,7 @@ pub async fn execute_instruction(
         let tx = PublicTransaction::new(message, witness_set);
 
         let tx_hash = wallet_core
-            .sequencer_client
+            .helm_owned()
             .send_transaction(LeeTransaction::Public(tx))
             .await
             .unwrap_or_else(|e| {
@@ -579,10 +577,7 @@ pub async fn execute_instruction(
         say!("   tx_hash: {}", tx_hash);
         say!("   Waiting for confirmation...");
 
-        let poller = wallet::poller::TxPoller::new(
-            wallet_core.config(),
-            wallet_core.sequencer_client.clone(),
-        );
+        let poller = wallet_core.poller_helm();
 
         match poller.poll_tx(tx_hash).await {
             Ok(_) => say!("✅ Transaction confirmed — included in a block."),
@@ -603,8 +598,8 @@ async fn fetch_nonces_best_effort(signer_ids: Vec<AccountId>) -> Vec<Option<Nonc
     }
     let len = signer_ids.len();
     let result = async {
-        let wc = WalletCore::from_env().ok()?;
-        wc.get_accounts_nonces(signer_ids).await.ok()
+        let wc = WalletCore::from_env().await.ok()?;
+        wc.get_accounts_nonces(&signer_ids).await.ok()
     }
     .await;
     match result {

--- a/spel-client-gen/src/codegen.rs
+++ b/spel-client-gen/src/codegen.rs
@@ -228,7 +228,7 @@ pub fn generate_client(idl: &SpelIdl) -> Result<String, String> {
         writeln!(out, "        ];").unwrap();
         writeln!(
             out,
-            "        let nonces = self.wallet.get_accounts_nonces(signer_ids.clone()).await"
+            "        let nonces = self.wallet.get_accounts_nonces(&signer_ids).await"
         )
         .unwrap();
         writeln!(
@@ -263,7 +263,7 @@ pub fn generate_client(idl: &SpelIdl) -> Result<String, String> {
             "        let tx = PublicTransaction::new(message, witness_set);"
         )
         .unwrap();
-        writeln!(out, "        let response = self.wallet.sequencer_client.send_transaction(common::transaction::LeeTransaction::Public(tx)).await").unwrap();
+        writeln!(out, "        let response = self.wallet.helm_owned().send_transaction(common::transaction::LeeTransaction::Public(tx)).await").unwrap();
         writeln!(
             out,
             "            .map_err(|e| format!(\"submit: {{}}\", e))?;"
@@ -302,8 +302,11 @@ pub fn generate_client(idl: &SpelIdl) -> Result<String, String> {
             write!(out, ", {pname}").unwrap();
         }
         writeln!(out, ");").unwrap();
-        writeln!(out, "        let account = self.wallet.sequencer_client").unwrap();
-        writeln!(out, "            .get_account(account_id).await").unwrap();
+        writeln!(
+            out,
+            "        let account = self.wallet.get_account_public(account_id).await"
+        )
+        .unwrap();
         writeln!(
             out,
             "            .map_err(|e| format!(\"fetch {}: {{}}\", e))?;",

--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -295,7 +295,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     .unwrap();
     writeln!(
         out,
-        "    WalletCore::from_env().map_err(|e| format!(\"wallet init: {{}}\", e))"
+        "    get_runtime().block_on(WalletCore::from_env()).map_err(|e| format!(\"wallet init: {{}}\", e))"
     )
     .unwrap();
     writeln!(out, "}}").unwrap();
@@ -492,7 +492,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
         writeln!(out, "    let tx_hash = rt.block_on(async {{").unwrap();
         writeln!(
             out,
-            "        let nonces = wallet.get_accounts_nonces(signer_ids.clone()).await"
+            "        let nonces = wallet.get_accounts_nonces(&signer_ids).await"
         )
         .unwrap();
         writeln!(
@@ -531,14 +531,14 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
             "        let tx = PublicTransaction::new(message, witness_set);"
         )
         .unwrap();
-        writeln!(out, "        let raw = wallet.sequencer_client.send_transaction(common::transaction::LeeTransaction::Public(tx)).await").unwrap();
+        writeln!(out, "        let raw = wallet.helm_owned().send_transaction(common::transaction::LeeTransaction::Public(tx)).await").unwrap();
         writeln!(
             out,
             "            .map_err(|e| format!(\"submit: {{}}\", e))?;"
         )
         .unwrap();
         writeln!(out, "        let tx_hash_hex = hex::encode(raw.0);").unwrap();
-        writeln!(out, "        let poller = wallet::poller::TxPoller::new(wallet.config(), wallet.sequencer_client.clone());").unwrap();
+        writeln!(out, "        let poller = wallet.poller_helm();").unwrap();
         writeln!(
             out,
             "        poller.poll_tx(raw).await.map_err(|e| format!(\"confirm: {{}}\", e))?;"
@@ -653,7 +653,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "    rt.block_on(async {{").unwrap();
     writeln!(
         out,
-        "        wallet.get_accounts_nonces(vec![]).await.map_err(|e| format!(\"ping: {{}}\", e))"
+        "        wallet.get_accounts_nonces(&[]).await.map_err(|e| format!(\"ping: {{}}\", e))"
     )
     .unwrap();
     writeln!(out, "    }})?;").unwrap();
@@ -689,7 +689,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "    let account_id = parse_account_id(v[\"account_id\"].as_str().ok_or(\"missing account_id\")?)?;").unwrap();
     writeln!(out, "    let rt = get_runtime();").unwrap();
     writeln!(out, "    let account = rt.block_on(async {{").unwrap();
-    writeln!(out, "        wallet.sequencer_client.get_account(account_id).await.map_err(|e| format!(\"get_account: {{}}\", e))").unwrap();
+    writeln!(out, "        wallet.get_account_public(account_id).await.map_err(|e| format!(\"get_account_public: {{}}\", e))").unwrap();
     writeln!(out, "    }})?;").unwrap();
     writeln!(
         out,
@@ -704,7 +704,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     )
     .unwrap();
     // program_owner classification
-    writeln!(out, "    let owner_bytes: Vec<u8> = account.program_owner.iter().flat_map(|w| w.to_le_bytes()).collect();").unwrap();
+    writeln!(out, "    let owner_bytes: Vec<u8> = account.program_owner.iter().flat_map(|w: &u32| w.to_le_bytes()).collect();").unwrap();
     writeln!(
         out,
         "    let program_owner_hex = hex::encode(&owner_bytes);"
@@ -899,7 +899,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "            let status = if let (Some(wallet), Ok(aid)) = (&maybe_wallet, parse_account_id(raw_id)) {{").unwrap();
     writeln!(
         out,
-        "                match wallet.sequencer_client.get_account(aid).await {{"
+        "                match wallet.get_account_public(aid).await {{"
     )
     .unwrap();
     writeln!(out, "                    Ok(account) => {{").unwrap();
@@ -1057,7 +1057,7 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "    let account_id = parse_account_id(v[\"account_id\"].as_str().ok_or(\"missing account_id\")?)?;").unwrap();
     writeln!(out, "    let rt = get_runtime();").unwrap();
     writeln!(out, "    let account = rt.block_on(async {{").unwrap();
-    writeln!(out, "        wallet.sequencer_client.get_account(account_id).await.map_err(|e| format!(\"get_account: {{}}\", e))").unwrap();
+    writeln!(out, "        wallet.get_account_public(account_id).await.map_err(|e| format!(\"get_account_public: {{}}\", e))").unwrap();
     writeln!(out, "    }})?;").unwrap();
     writeln!(out, "    if account.data.is_empty() {{").unwrap();
     writeln!(out, "        return Ok(json!({{\"success\": true, \"status\": \"uninitialized\", \"type\": null, \"fields\": null}}).to_string());").unwrap();
@@ -1532,7 +1532,7 @@ pub fn generate_account_fetch_functions(idl: &SpelIdl, prefix: &str, out: &mut S
             writeln!(out, "    ])?;").unwrap();
             writeln!(out, "    let rt = get_runtime();").unwrap();
             writeln!(out, "    let account = rt.block_on(async {{").unwrap();
-            writeln!(out, "        wallet.sequencer_client.get_account(pda).await.map_err(|e| format!(\"get_account: {{e}}\"))").unwrap();
+            writeln!(out, "        wallet.get_account_public(pda).await.map_err(|e| format!(\"get_account_public: {{e}}\"))").unwrap();
             writeln!(out, "    }})?;").unwrap();
             writeln!(out, "    let idl: spel_framework_core::idl::SpelIdl = serde_json::from_str(PROGRAM_IDL_JSON).map_err(|e| format!(\"IDL: {{e}}\"))?;").unwrap();
             writeln!(out, "    let state = match spel_framework_core::decode::decode_account_data_try_all(&account.data, &idl) {{").unwrap();

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -697,7 +697,7 @@ fn test_fetch_helpers() {
 
     // Fetch helper gets account from sequencer
     assert!(
-        code.contains("get_account(account_id)"),
+        code.contains("get_account_public(account_id)"),
         "fetch helper should fetch account data"
     );
 
@@ -1314,10 +1314,10 @@ fn test_ffi_fetch_decode_and_response() {
         ffi.contains("decode_account_data_try_all"),
         "fetch function must use decode_account_data_try_all: {ffi}"
     );
-    // Must call get_account
+    // Must call get_account_public
     assert!(
-        ffi.contains("get_account(pda)"),
-        "fetch function must call get_account(pda): {ffi}"
+        ffi.contains("get_account_public(pda)"),
+        "fetch function must call get_account_public(pda): {ffi}"
     );
     // Must return success JSON with state
     assert!(

--- a/spel-ffi-compile-test/Cargo.toml
+++ b/spel-ffi-compile-test/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 spel-client-gen = { path = "../spel-client-gen" }
 
 [dependencies]
-nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
-nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
-common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
-wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee" }
+nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee_core" }
+common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", features = ["client"] }
+wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4" }
 serde_json  = "1"
 serde       = { version = "1", features = ["derive"] }
 borsh       = "1.5"

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -14,7 +14,7 @@ idl-gen = ["dep:syn", "dep:proc-macro2", "dep:toml"]
 host = ["dep:nssa"]
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", features = ["host"], package = "lee_core" }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -22,7 +22,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 base58 = { version = "0.2", optional = true }
 
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", optional = true, package = "lee" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", optional = true, package = "lee" }
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }
 proc-macro2 = { version = "1.0", optional = true }

--- a/spel-framework-core/src/pda.rs
+++ b/spel-framework-core/src/pda.rs
@@ -2,6 +2,7 @@
 
 use base58::FromBase58;
 use nssa_core::account::AccountId;
+use nssa_core::encryption::ViewingPublicKey;
 use nssa_core::program::{PdaSeed, ProgramId};
 use nssa_core::NullifierPublicKey;
 use sha2::{Digest, Sha256};
@@ -90,11 +91,14 @@ pub fn compute_pda(program_id: &ProgramId, seeds: &[&[u8; 32]]) -> AccountId {
 }
 
 /// Derive a **private** PDA `AccountId` from a program ID, one or more 32-byte seeds,
-/// and a `NullifierPublicKey`.
+/// a `NullifierPublicKey`, and a `ViewingPublicKey`.
 ///
 /// The seed combining logic mirrors [`compute_pda`]; the difference is the final
-/// derivation calls `AccountId::for_private_pda`, which includes the `npk` in the
-/// hash so each controller group gets a unique address for the same seed.
+/// derivation calls `AccountId::for_private_pda`, which includes the `npk` and `vpk`
+/// in the hash so each controller group gets a unique address for the same seed.
+///
+/// Since LEZ v0.2.1 the derivation formula is:
+/// `SHA256(prefix || program_id || seed || npk || vpk || identifier)`
 ///
 /// # Panics
 ///
@@ -103,6 +107,7 @@ pub fn compute_private_pda(
     program_id: &ProgramId,
     seeds: &[&[u8; 32]],
     npk: &NullifierPublicKey,
+    vpk: &ViewingPublicKey,
 ) -> AccountId {
     assert!(!seeds.is_empty(), "PDA requires at least one seed");
 
@@ -117,9 +122,8 @@ pub fn compute_private_pda(
     };
 
     let pda_seed = PdaSeed::new(combined);
-    // lez-core-v0.2.0 added a u128 `identifier` to private-PDA derivation; default
-    // to 0 (the common case) until callers need to pass a specific identifier.
-    AccountId::for_private_pda(program_id, &pda_seed, npk, 0)
+    // identifier defaults to 0, the common case for single-purpose PDAs.
+    AccountId::for_private_pda(program_id, &pda_seed, npk, vpk, 0)
 }
 
 /// Compute a PDA from a program ID and multiple [`ToSeed`] values.

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -184,10 +184,12 @@ struct AccountConstraints {
     owner: Option<syn::Expr>,
     signer: bool,
     pda_seeds: Vec<PdaSeedDef>,
-    /// True when `private_pda` keyword is present — address includes the caller's npk.
+    /// True when `private_pda` keyword is present — address includes the caller's npk + vpk.
     private_pda: bool,
     /// Name of the instruction arg supplying the `NullifierPublicKey` for derivation.
     npk_arg: Option<String>,
+    /// Name of the instruction arg supplying the `ViewingPublicKey` for derivation.
+    vpk_arg: Option<String>,
 }
 
 /// A PDA seed definition from the `#[account(pda = ...)]` attribute.
@@ -650,6 +652,23 @@ fn parse_account_constraints(attrs: &[Attribute]) -> syn::Result<AccountConstrai
                         }
                     }
                     Err(meta.error("npk must be npk = arg(\"arg_name\")"))
+                } else if meta.path.is_ident("vpk") {
+                    // vpk = arg("arg_name") — instruction arg supplying the ViewingPublicKey
+                    let value = meta.value()?;
+                    let expr: syn::Expr = value.parse()?;
+                    if let syn::Expr::Call(call) = &expr {
+                        if let syn::Expr::Path(path) = &*call.func {
+                            if path.path.is_ident("arg") {
+                                if let Some(syn::Expr::Lit(lit)) = call.args.first() {
+                                    if let syn::Lit::Str(s) = &lit.lit {
+                                        constraints.vpk_arg = Some(s.value());
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(meta.error("vpk must be vpk = arg(\"arg_name\")"))
                 } else {
                     Err(meta.error("unknown account constraint"))
                 }
@@ -671,6 +690,12 @@ fn parse_account_constraints(attrs: &[Attribute]) -> syn::Result<AccountConstrai
                 "`private_pda` requires `npk = arg(\"arg_name\")`",
             ));
         }
+        if constraints.vpk_arg.is_none() {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`private_pda` requires `vpk = arg(\"arg_name\")` (LEZ v0.2.1+)",
+            ));
+        }
         // Validate the npk arg name is a valid Rust identifier
         let npk_name = constraints.npk_arg.as_deref().unwrap();
         if syn::parse_str::<Ident>(npk_name).is_err() {
@@ -679,10 +704,23 @@ fn parse_account_constraints(attrs: &[Attribute]) -> syn::Result<AccountConstrai
                 format!("`npk` arg name `{npk_name}` is not a valid Rust identifier"),
             ));
         }
+        // Validate the vpk arg name is a valid Rust identifier
+        let vpk_name = constraints.vpk_arg.as_deref().unwrap();
+        if syn::parse_str::<Ident>(vpk_name).is_err() {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("`vpk` arg name `{vpk_name}` is not a valid Rust identifier"),
+            ));
+        }
     } else if constraints.npk_arg.is_some() {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             "`npk` can only be used together with `private_pda`",
+        ));
+    } else if constraints.vpk_arg.is_some() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`vpk` can only be used together with `private_pda`",
         ));
     }
 
@@ -905,8 +943,25 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
                 }).collect()
             };
 
+            // Collect vpk arg values for private PDA accounts
+            let vpk_arg_values: Vec<TokenStream2> = {
+                let mut names = Vec::new();
+                for acc in &ix.accounts {
+                    if let Some(ref vpk) = acc.constraints.vpk_arg {
+                        if !names.contains(vpk) {
+                            names.push(vpk.clone());
+                        }
+                    }
+                }
+                names.iter().map(|name| {
+                    let arg_ident = format_ident!("{}", name);
+                    quote! { &#arg_ident }
+                }).collect()
+            };
+
             let all_extra_args: Vec<TokenStream2> = arg_seed_values.iter()
                 .chain(npk_arg_values.iter())
+                .chain(vpk_arg_values.iter())
                 .cloned()
                 .collect();
 
@@ -1460,6 +1515,22 @@ fn generate_validation(instructions: &[InstructionInfo]) -> Vec<TokenStream2> {
                 params
             };
 
+            // Extra parameters for private PDA vpk args: __vpk_arg_<name>: &nssa_core::encryption::ViewingPublicKey
+            let vpk_params: Vec<TokenStream2> = {
+                let mut seen: Vec<String> = Vec::new();
+                let mut params = Vec::new();
+                for acc in &ix.accounts {
+                    if let Some(ref vpk) = acc.constraints.vpk_arg {
+                        if !seen.contains(vpk) {
+                            seen.push(vpk.clone());
+                            let ident = format_ident!("__vpk_arg_{}", vpk);
+                            params.push(quote! { #ident: &nssa_core::encryption::ViewingPublicKey });
+                        }
+                    }
+                }
+                params
+            };
+
             // Generate PDA checks for accounts with pda_seeds
             let pda_checks: Vec<TokenStream2> = ix
                 .accounts
@@ -1507,15 +1578,18 @@ fn generate_validation(instructions: &[InstructionInfo]) -> Vec<TokenStream2> {
                         .collect();
 
                     if acc.constraints.private_pda {
-                        // Private PDA: address = for_private_pda(program_id, seed, npk)
+                        // Private PDA: address = for_private_pda(program_id, seed, npk, vpk)
                         let npk_name = acc.constraints.npk_arg.as_deref()
                             .expect("private_pda without npk_arg — should have been caught in parse_account_constraints");
                         let npk_param = format_ident!("__npk_arg_{}", npk_name);
+                        let vpk_name = acc.constraints.vpk_arg.as_deref()
+                            .expect("private_pda without vpk_arg — should have been caught in parse_account_constraints");
+                        let vpk_param = format_ident!("__vpk_arg_{}", vpk_name);
                         quote! {
                             {
                                 #(#seed_exprs)*
                                 let __expected_id = spel_framework::pda::compute_private_pda(
-                                    self_program_id, &[#(#seed_refs),*], #npk_param
+                                    self_program_id, &[#(#seed_refs),*], #npk_param, #vpk_param
                                 );
                                 if accounts[#idx].account_id != __expected_id {
                                     return Err(spel_framework::error::SpelError::PdaMismatch {
@@ -1550,9 +1624,10 @@ fn generate_validation(instructions: &[InstructionInfo]) -> Vec<TokenStream2> {
                 return quote! {};
             }
 
-            // Combine all extra params: arg seeds first, then npk params
+            // Combine all extra params: arg seeds, then npk params, then vpk params
             let all_validate_params: Vec<TokenStream2> = arg_seed_params.into_iter()
                 .chain(npk_params)
+                .chain(vpk_params)
                 .collect();
 
             quote! {

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -11,8 +11,8 @@ host = ["dep:nssa", "spel-framework-core/host"]
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", optional = true, package = "lee" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", features = ["host"], package = "lee_core" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", optional = true, package = "lee" }
 borsh = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 

--- a/test-modules/test_modules_ffi/Cargo.toml
+++ b/test-modules/test_modules_ffi/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
-nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
-common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
-wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee" }
+nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee_core" }
+common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", features = ["client"] }
+wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4" }
 spel-framework-core = { path = "../../spel-framework-core" }
 serde_json  = "1"
 serde       = { version = "1", features = ["derive"] }

--- a/tests/e2e/fixture_program/Cargo.lock
+++ b/tests/e2e/fixture_program/Cargo.lock
@@ -1040,7 +1040,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=lez-core-v0.2.0#fb8cbac40e0bda4f152415ff4f181cdc6bca6d4a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.4#47eba256479f6f785acbd138834340703cd03401"
 dependencies = [
  "base58",
  "borsh",
@@ -1789,7 +1789,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base58",
  "borsh",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/e2e/fixture_program/Cargo.toml
+++ b/tests/e2e/fixture_program/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 spel-framework = { path = "../../../spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", features = ["host"], package = "lee_core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tests/e2e/fixture_program/src/lib.rs
+++ b/tests/e2e/fixture_program/src/lib.rs
@@ -102,14 +102,15 @@ mod treasury {
         Ok(SpelOutput::execute(vec![record, owner], vec![]))
     }
 
-    /// Initialize a private PDA — address is unique per (seed, npk) pair.
+    /// Initialize a private PDA — address is unique per (seed, npk, vpk) tuple.
     #[instruction]
     pub fn init_private_account(
-        #[account(init, private_pda, pda = literal("private_vault"), npk = arg("user_npk"))]
+        #[account(init, private_pda, pda = literal("private_vault"), npk = arg("user_npk"), vpk = arg("user_vpk"))]
         account: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
         user_npk: nssa_core::NullifierPublicKey,
+        user_vpk: nssa_core::encryption::ViewingPublicKey,
     ) -> SpelResult {
         Ok(SpelOutput::execute(vec![account, authority], vec![]))
     }
@@ -690,14 +691,20 @@ mod tests {
         nssa_core::NullifierPublicKey([byte; 32])
     }
 
+    fn make_vpk(d: u8, z: u8) -> nssa_core::encryption::ViewingPublicKey {
+        nssa_core::encryption::ViewingPublicKey::from_seed(&[d; 32], &[z; 32])
+    }
+
     #[test]
     fn validate_init_private_account_accepts_correct_address() {
         let program_id = test_program_id();
         let npk = make_npk(0xAB);
+        let vpk = make_vpk(0x01, 0x02);
         let correct_id = spel_framework::pda::compute_private_pda(
             &program_id,
             &[&spel_framework::pda::seed_from_str("private_vault")],
             &npk,
+            &vpk,
         );
         let accounts = vec![
             make_account_with_id(*correct_id.value(), false), // account — correct private PDA
@@ -708,6 +715,7 @@ mod tests {
             &program_id,
             &empty_ix_data(),
             &npk,
+            &vpk,
         );
         assert!(result.is_ok(), "correct private PDA should pass: {result:?}");
     }
@@ -717,10 +725,12 @@ mod tests {
         let program_id = test_program_id();
         let correct_npk = make_npk(0xAB);
         let wrong_npk = make_npk(0xCD);
+        let vpk = make_vpk(0x01, 0x02);
         let correct_id = spel_framework::pda::compute_private_pda(
             &program_id,
             &[&spel_framework::pda::seed_from_str("private_vault")],
             &correct_npk,
+            &vpk,
         );
         // Supply the address for correct_npk but validate with wrong_npk
         let accounts = vec![
@@ -732,6 +742,7 @@ mod tests {
             &program_id,
             &empty_ix_data(),
             &wrong_npk,
+            &vpk,
         );
         let err = result.expect_err("wrong npk should fail");
         assert!(
@@ -744,6 +755,7 @@ mod tests {
     fn validate_init_private_account_rejects_public_pda_address() {
         let program_id = test_program_id();
         let npk = make_npk(0xAB);
+        let vpk = make_vpk(0x01, 0x02);
         // Supply the PUBLIC PDA address — should be rejected
         let public_id = spel_framework::pda::compute_pda(
             &program_id,
@@ -758,6 +770,7 @@ mod tests {
             &program_id,
             &empty_ix_data(),
             &npk,
+            &vpk,
         );
         assert!(
             result.is_err(),


### PR DESCRIPTION
## Summary
Migrates the entire SPEL ecosystem to LEZ v0.2.4, addressing all breaking API changes introduced by the multi-sequencer architecture and the ML-KEM-768 ViewingPublicKey integration in private PDA derivation.

## Motivation
LEZ v0.2.4 introduced three categories of breaking changes:
1. `WalletCore::from_env()` became async
2. Direct `wallet.sequencer_client` field access was replaced by `helm_owned()` / `poller_helm()` / `get_account_public()` abstractions
3. `AccountId::for_private_pda()` now requires a `ViewingPublicKey` (1184-byte ML-KEM-768 encapsulation key) in the derivation formula:
`SHA256(prefix || program_id || seed || npk || vpk || identifier)`

Without this migration, SPEL CLI cannot interact with LEZ v0.2.4 sequencers, and private PDA addresses would be computed incorrectly.

## Changes
### Dependency Bumps (8 files)
All LEZ crates pinned to `tag = "v0.2.4"`:
- `nssa_core` / `nssa` / `common` / `sequencer_service_rpc` / `wallet`
- `spel-cli`, `spel-framework-core`, `spel-framework`, `spel-ffi-compile-test`, `test-modules/test_modules_ffi`, `tests/e2e/fixture_program`

### WalletCore API Migration (5 files)
| Old API (v0.2.0) | New API (v0.2.4) |
|---|---|
| `WalletCore::from_env()` (sync) | `WalletCore::from_env().await` (async) |
| `wallet.sequencer_client.send_transaction(...)` | `wallet.helm_owned().send_transaction(...)` |
| `wallet.sequencer_client.get_account(id)` | `wallet.get_account_public(id)` |
| `TxPoller::new(config, client)` | `wallet.poller_helm()` |
| `get_accounts_nonces(Vec<AccountId>)` | `get_accounts_nonces(&[AccountId])` |

Files: `account_inspect.rs`, `tx.rs`, `codegen.rs`, `ffi_codegen.rs`

### ViewingPublicKey Integration (5 files)
- **`spel-framework-core/src/pda.rs`**: Added `compute_private_pda()` with `vpk: &ViewingPublicKey` parameter
- **`spel-framework-macros/src/lib.rs`**: Added `vpk = arg("...")` macro attribute for `#[spel_program]` private PDA validation codegen (+83 lines)
- **`spel-cli/src/pda.rs`**: Added `vpk: Option<&ViewingPublicKey>` to `compute_pda_from_seeds()`; returns error if npk is provided without vpk
- **`spel-cli/src/lib.rs`**: CLI `pda` subcommand now parses `--vpk <hex>` (2368 hex chars = 1184 bytes) for private PDAs
- **`spel-cli/Cargo.toml`**: Enabled `features = ["host"]` on `lee_core` for `ViewingPublicKey::from_bytes()`

### Fixture Program (2 files)
- Updated all 39 tests to use the new VPK-aware PDA derivation
- All tests pass 

## Testing
```bash
cargo check --workspace # ✅ 0 errors
cargo test --manifest-path tests/e2e/fixture_program/Cargo.toml # ✅ 39/39 passed
cargo install --path spel-cli --force # ✅ binary re-installed
```
