### PR TITLE
fix(ci): patch the wallet config schema LEZ v0.2.1+ actually reads

### DIFF
--- a/scripts/ffi-call-test.sh
+++ b/scripts/ffi-call-test.sh
@@ -227,15 +227,27 @@ done
 log "Step 5: Updating wallet config for port ${SEQUENCER_PORT}..."
 WALLET_CONFIG="${NSSA_WALLET_HOME_DIR}/wallet_config.json"
 if [ -f "$WALLET_CONFIG" ]; then
-    python3 -c "
-import json
-with open('$WALLET_CONFIG', 'r') as f:
+    # LEZ v0.2.1+ moved the sequencer address into a `sequencers` array; older
+    # revisions used a flat `sequencer_addr`. Patch whichever schema this wallet
+    # build expects — writing the wrong one is silently ignored by serde and the
+    # wallet then talks to the default port (spel/co #256).
+    # Paths/URLs are passed as argv so special characters can't break the script.
+    python3 -c '
+import json, sys
+path, url = sys.argv[1], sys.argv[2]
+with open(path) as f:
     config = json.load(f)
-config['sequencer_addr'] = '$SEQUENCER_URL'
-with open('$WALLET_CONFIG', 'w') as f:
+if isinstance(config.get("sequencers"), list):
+    entry = config["sequencers"][0] if config["sequencers"] else {}
+    entry["sequencer_addr"] = url
+    config["sequencers"] = [entry]
+    config.pop("sequencer_addr", None)
+else:
+    config["sequencer_addr"] = url
+with open(path, "w") as f:
     json.dump(config, f, indent=4)
-print('  ✓ Updated wallet config to use $SEQUENCER_URL')
-" || warn "Failed to update wallet config"
+print("  \u2713 Updated wallet config to use " + url)
+' "$WALLET_CONFIG" "$SEQUENCER_URL" || warn "Failed to update wallet config"
 else
     warn "Wallet config not found at $WALLET_CONFIG"
 fi

--- a/scripts/init-e2e-test.sh
+++ b/scripts/init-e2e-test.sh
@@ -221,15 +221,27 @@ done
 log "Step 5: Updating wallet config for port ${SEQUENCER_PORT}..."
 WALLET_CONFIG="${NSSA_WALLET_HOME_DIR}/wallet_config.json"
 if [ -f "$WALLET_CONFIG" ]; then
-    python3 -c "
-import json
-with open('$WALLET_CONFIG', 'r') as f:
+    # LEZ v0.2.1+ moved the sequencer address into a `sequencers` array; older
+    # revisions used a flat `sequencer_addr`. Patch whichever schema this wallet
+    # build expects — writing the wrong one is silently ignored by serde and the
+    # wallet then talks to the default port (spel/co #256).
+    # Paths/URLs are passed as argv so special characters can't break the script.
+    python3 -c '
+import json, sys
+path, url = sys.argv[1], sys.argv[2]
+with open(path) as f:
     config = json.load(f)
-config['sequencer_addr'] = '$SEQUENCER_URL'
-with open('$WALLET_CONFIG', 'w') as f:
+if isinstance(config.get("sequencers"), list):
+    entry = config["sequencers"][0] if config["sequencers"] else {}
+    entry["sequencer_addr"] = url
+    config["sequencers"] = [entry]
+    config.pop("sequencer_addr", None)
+else:
+    config["sequencer_addr"] = url
+with open(path, "w") as f:
     json.dump(config, f, indent=4)
-print('  ✓ Updated wallet config to use $SEQUENCER_URL')
-" || warn "Failed to update wallet config"
+print("  \u2713 Updated wallet config to use " + url)
+' "$WALLET_CONFIG" "$SEQUENCER_URL" || warn "Failed to update wallet config"
 else
     warn "Wallet config not found at $WALLET_CONFIG — wallet may fail to connect"
 fi


### PR DESCRIPTION
## Problem

`init-e2e-test.sh` and `ffi-call-test.sh` fail against LEZ v0.2.4 with:

```
Error: Failed to find leader
[FAIL] Deploy failed
```

Both scripts point the wallet at a non-default sequencer port by writing a top-level
`sequencer_addr` into `wallet_config.json`. **LEZ v0.2.1 moved that field into a
`sequencers` array:**

```rust
// lez/wallet/src/config.rs (v0.2.4)
pub struct WalletConfig {
    pub sequencers: Vec<SequencerConnectionData>,   // <- was: sequencer_addr: Url
    ...
}
pub struct SequencerConnectionData {
    pub sequencer_addr: Url,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub basic_auth: Option<BasicAuth>,
}
```

The config is parsed with plain serde (no `deny_unknown_fields`), so the old top-level key
is **silently ignored** — the wallet keeps talking to the default port 3040, where nothing
is listening, and reports `Failed to find leader`.

This also explains why only two of the three e2e jobs fail: `smoke-test-privacy.sh` runs on
the default port 3040 and never patches the config at all, so it passes either way.

## Fix

Patch whichever schema the config presents, so the scripts keep working across old and new
LEZ revisions (same pattern the scripts already use for the `lez/` config path move and the
`NSSA_WALLET_HOME_DIR` → `LEE_WALLET_HOME_DIR` rename). Existing entry fields such as
`basic_auth` are preserved, and the URL is passed via `argv` rather than interpolated into
the Python source, matching the existing sequencer-config patch in `init-e2e-test.sh`.

## Verification

Reproduced and fixed locally against a **real LEZ v0.2.4 build** (`sequencer_service` +
`wallet` built from tag `v0.2.4` = `47eba256`, the same commit CI checks out), using a
listener on the non-default port 3043 to observe which port the wallet actually dials:

| wallet_config.json patched as | wallet dials 3043? | result |
|---|---|---|
| `sequencer_addr` (today's `main`) | **no** — 0 connections | `Error: Failed to find leader` ← reproduces CI exactly |
| `sequencers[0].sequencer_addr` (this PR) | **yes** — 100+ connections | proceeds past sequencer connection |

The patch logic was also unit-checked against both real config shapes (v0.2.0 flat and the
v0.2.4 array, including a `basic_auth` entry to confirm it is preserved).

## Why this is separate from #256

#256 (LEZ v0.2.4 migration) does not touch `scripts/`, and this fix is schema-detecting, so
it is safe to merge on `main` **before** #256: on today's LEZ v0.2.0 it takes the flat-schema
branch and behaves exactly as before. Merging this first means #256 goes green on rebase.

## Not addressed here

The `Waiting for sequencer...` loop in both scripts exhausts its full timeout (90 x 2s in
init-e2e) and then **continues silently** — there is no `fail` on timeout, so a sequencer that
never comes up surfaces later as a confusing deploy error instead of a clear one. Worth a
follow-up; left out to keep this PR to the one blocking change.
