### PR TITLE
fix(macros): claim signer accounts while they are still default-owned

### DIFF
--- a/spel-framework-core/src/spel_output.rs
+++ b/spel-framework-core/src/spel_output.rs
@@ -28,6 +28,13 @@ use crate::types::{IntoPostState, SpelOutput};
 pub enum AutoClaim {
     /// The account should be claimed with the given [`Claim`] type.
     Claimed(Claim),
+    /// The account should be claimed only when it is still owned by the default
+    /// program — the shape LEZ's own reference programs use for an authorizing
+    /// account. A user account that no program has claimed yet is default-owned;
+    /// once it has transacted its pre-state is no longer `Account::default()`, and
+    /// LEZ rule 7 rejects any output that returns it still default-owned. Claiming
+    /// it the first time a program touches it keeps it valid from then on.
+    ClaimedIfDefault(Claim),
     /// The account is mutable or read-only — no claim is requested.
     None,
 }
@@ -36,7 +43,7 @@ impl AutoClaim {
     /// Returns `true` if this will result in `AccountPostState::new_claimed`.
     #[must_use]
     pub fn is_claimed(&self) -> bool {
-        matches!(self, AutoClaim::Claimed(_))
+        matches!(self, AutoClaim::Claimed(_) | AutoClaim::ClaimedIfDefault(_))
     }
 
     /// Convert an account and this auto-claim into an `AccountPostState`.
@@ -44,6 +51,9 @@ impl AutoClaim {
     pub fn to_post_state(&self, account: Account) -> AccountPostState {
         match self {
             AutoClaim::Claimed(claim) => AccountPostState::new_claimed(account, *claim),
+            AutoClaim::ClaimedIfDefault(claim) => {
+                AccountPostState::new_claimed_if_default(account, *claim)
+            },
             AutoClaim::None => AccountPostState::new(account),
         }
     }

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -1237,6 +1237,16 @@ fn generate_single_claim_expr(acc: &AccountParam) -> TokenStream2 {
                 nssa_core::program::Claim::Authorized
             )
         }
+    } else if acc.constraints.signer {
+        // A signer is a plain user account: default-owned until some program claims
+        // it. LEZ rule 7 forbids returning a non-default account that is still
+        // default-owned, so claim it while it is still default — exactly what LEZ's
+        // own `hello_world_with_authorization` does via `new_claimed_if_default`.
+        quote! {
+            spel_framework::spel_output::AutoClaim::ClaimedIfDefault(
+                nssa_core::program::Claim::Authorized
+            )
+        }
     } else {
         quote! { spel_framework::spel_output::AutoClaim::None }
     }

--- a/tests/e2e/fixture_program/src/lib.rs
+++ b/tests/e2e/fixture_program/src/lib.rs
@@ -568,10 +568,16 @@ mod tests {
             &claims[0]
         );
 
-        // owner (index 1): signer only, not init → no claim
+        // owner (index 1): signer → claimed only while still default-owned, so a
+        // used wallet account is never returned default-owned (LEZ rule 7).
         assert!(
-            matches!(&claims[1], spel_framework::spel_output::AutoClaim::None),
-            "owner claim should be None, got: {:?}",
+            matches!(
+                &claims[1],
+                spel_framework::spel_output::AutoClaim::ClaimedIfDefault(
+                    nssa_core::program::Claim::Authorized
+                )
+            ),
+            "owner claim should be ClaimedIfDefault(Authorized), got: {:?}",
             &claims[1]
         );
 
@@ -658,7 +664,11 @@ mod tests {
     fn claims_batch_update_rest_count() {
         let claims = treasury::__claims_batch_update(3);
         assert_eq!(claims.len(), 4); // 1 fixed (authority) + 3 rest (targets)
-        assert!(matches!(&claims[0], spel_framework::spel_output::AutoClaim::None)); // authority
+        // authority is a signer → ClaimedIfDefault (see LEZ rule 7)
+        assert!(matches!(
+            &claims[0],
+            spel_framework::spel_output::AutoClaim::ClaimedIfDefault(_)
+        ));
         for claim in &claims[1..] {
             assert!(matches!(claim, spel_framework::spel_output::AutoClaim::None)); // targets
         }
@@ -767,7 +777,8 @@ mod tests {
             matches!(&claims[0], AutoClaim::Claimed(Claim::Pda(_))),
             "private PDA account must emit Claim::Pda"
         );
-        assert!(matches!(&claims[1], AutoClaim::None)); // authority
+        // authority is a signer → ClaimedIfDefault (see LEZ rule 7)
+        assert!(matches!(&claims[1], AutoClaim::ClaimedIfDefault(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

LEZ **rule 7** (`lee/state_machine/core/src/program/mod.rs`) rejects any program output that
returns a non-default account still owned by `DEFAULT_PROGRAM_ID`:

```rust
// 7. If a post state has default program owner, the pre state must have been a default account
if post.account.program_owner == DEFAULT_PROGRAM_ID && pre.account != Account::default() {
    return Err(NonDefaultAccountWithDefaultOwner { account_id });
}
```

A signer is a plain user account — default-owned until some program claims it. The macro only
emits claims for `init` accounts, so a plain `#[account(signer)]` fell through to
`AutoClaim::None` and was **never claimed**:

```
#[account(init, pda = ...)] → Claim::Pda(seeds)
#[account(init, signer)]    → Claim::Authorized
#[account(init)]            → Claim::Authorized
#[account(signer)]          → None          ← never claimed
```

That is legal on the signer's *first* transaction (its pre-state still equals
`Account::default()`), but the nonce then bumps to 1 and the account is permanently
non-default **and** default-owned — so every later transaction declaring it is rejected.

## Fix

Claim the signer while it is still default, which is exactly what LEZ's own
`hello_world_with_authorization` reference program does via
`AccountPostState::new_claimed_if_default(account, Claim::Authorized)` — a constructor SPEL
never used. Adds `AutoClaim::ClaimedIfDefault(Claim)` mapping to it, and makes
`#[account(signer)]` emit it.

## Verification

Reproduced and fixed against a **real LEZ v0.2.4 chain** (sequencer + wallet built from tag
`v0.2.4`, `--features standalone`):

| | before | after |
|---|---|---|
| `initialize` (1st TX, fresh signer) | pass | pass |
| `do_something` (2nd TX, same signer) | **`DeclaredAccountMissingFromOutput`** | **pass** |
| `do_something` (3rd, 4th) | — | **pass** |
| sequencer rejections | 1 per run | **0** |

`cargo test --workspace`: **270 passed, 0 failed** — against LEZ **v0.2.0** (this branch's pin),
so the change is safe ahead of the v0.2.4 bump. Three fixture tests asserted the old
`AutoClaim::None` for signers and now assert the new behaviour.

## Why this is separate from #256

The bug is latent on v0.2.0 (rule 7 was only enforced against *declared* accounts from v0.2.1's
`DeclaredAccountMissingFromOutput`), so it is not a v0.2.4 change per se — and landing it on
`main` first means #256 picks it up on rebase rather than growing further.

## Note for reviewers

This changes claim semantics for **every** `#[account(signer)]` in every SPEL program: the first
program a user transacts with now takes ownership of their account. That appears to be LEZ's
intended model — it is what their reference program does and rule 7 leaves no alternative — but
two things are **not** covered by the testing above and deserve a look:

- using the same wallet account with a **second** program afterwards;
- interaction with balance transfers (rule 5 restricts balance decreases to the owning program).

Probably also wants a CHANGELOG entry.
