### PR TITLE
fix(cli): parse Vec<u64>, Vec<u128> and Vec<bool> arguments from comma-separated lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ spel --idl program-idl.json create-vault --help
 | `[u32; 8]` / `program_id` | Comma-separated u32s: `"0,0,0,0,0,0,0,0"` |
 | `Vec<u8>` | Comma-separated decimal bytes: `"0,1,2"` |
 | `Vec<u32>` | Comma-separated decimal u32s: `"0,200,0,0,0"` |
+| `Vec<u64>` / `Vec<u128>` / `Vec<bool>` | Comma-separated values: `"300,700"`, `"true,false"`; `""` is an empty list |
 | `Vec<[u8; 32]>` | Comma-separated hex or base58: `"addr1,addr2"` |
 | `rest` accounts | Comma-separated base58/hex: `--foo-account "addr1,addr2"` |
 | `Option<T>` | Value or `"none"` |

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ spel --idl program-idl.json create-vault --help
 | `[u32; 8]` / `program_id` | Comma-separated u32s: `"0,0,0,0,0,0,0,0"` |
 | `Vec<u8>` | Comma-separated decimal bytes: `"0,1,2"` |
 | `Vec<u32>` | Comma-separated decimal u32s: `"0,200,0,0,0"` |
-| `Vec<u64>` / `Vec<u128>` / `Vec<bool>` | Comma-separated values: `"300,700"`, `"true,false"`; `""` is an empty list |
+| `Vec<u64>` / `Vec<u128>` / `Vec<bool>` | Comma-separated values: `"300,700"`, `"true,false"`; `""` is an empty list; an empty element (`"1,,2"`) is an error |
 | `Vec<[u8; 32]>` | Comma-separated hex or base58: `"addr1,addr2"` |
 | `rest` accounts | Comma-separated base58/hex: `--foo-account "addr1,addr2"` |
 | `Option<T>` | Value or `"none"` |

--- a/spel-cli/src/parse.rs
+++ b/spel-cli/src/parse.rs
@@ -16,6 +16,7 @@ pub enum ParsedValue {
     U32Array(Vec<u32>),         // [u32; N] / ProgramId
     ByteArrayVec(Vec<Vec<u8>>), // Vec<[u8; 32]>
     StringVec(Vec<String>),     // Vec<String>
+    Seq(Vec<ParsedValue>),      // Vec<T> for any other primitive T (u64, u128, bool)
     None,                       // Option::None
     Some(Box<ParsedValue>),     // Option::Some
     Raw(String),                // fallback
@@ -53,6 +54,10 @@ impl std::fmt::Display for ParsedValue {
             ParsedValue::StringVec(strs) => {
                 let quoted: Vec<String> = strs.iter().map(|s| format!("\"{}\"", s)).collect();
                 write!(f, "[{}]", quoted.join(", "))
+            },
+            ParsedValue::Seq(items) => {
+                let strs: Vec<String> = items.iter().map(|v| v.to_string()).collect();
+                write!(f, "[{}]", strs.join(", "))
             },
             ParsedValue::None => write!(f, "None"),
             ParsedValue::Some(inner) => write!(f, "Some({})", inner),
@@ -296,6 +301,23 @@ fn parse_vec(raw: &str, elem_type: &IdlType) -> Result<ParsedValue, String> {
                 Err(_) => Ok(ParsedValue::Raw(raw.to_string())),
             }
         },
+        // Vec<u64> / Vec<u128> / Vec<bool> — comma-separated values, parsed element by
+        // element with the primitive parser; an empty (or whitespace-only) string is an
+        // empty list.
+        IdlType::Primitive(p) if p == "u64" || p == "u128" || p == "bool" => {
+            let mut items = Vec::new();
+            for (i, part) in raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .enumerate()
+            {
+                let item =
+                    parse_primitive(part, p).map_err(|e| format!("Element [{}]: {}", i, e))?;
+                items.push(item);
+            }
+            Ok(ParsedValue::Seq(items))
+        },
         _ => Ok(ParsedValue::Raw(raw.to_string())),
     }
 }
@@ -433,5 +455,82 @@ mod tests {
         // Fail-closed for junk that doesn't decode to a 32-byte ImageID.
         assert!(parse_program_id("not-a-program-id").is_err());
         assert!(parse_program_id("deadbeef").is_err());
+    }
+
+    fn vec_of(prim: &str) -> IdlType {
+        IdlType::Vec {
+            vec: Box::new(IdlType::Primitive(prim.to_string())),
+        }
+    }
+
+    #[test]
+    fn parse_vec_u128_from_csv() {
+        let parsed = parse_value(
+            "300, 700,340282366920938463463374607431768211455",
+            &vec_of("u128"),
+        )
+        .expect("Vec<u128> parses from a comma-separated list");
+        match parsed {
+            ParsedValue::Seq(items) => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], ParsedValue::U128(300)));
+                assert!(matches!(items[1], ParsedValue::U128(700)));
+                assert!(matches!(items[2], ParsedValue::U128(u128::MAX)));
+            },
+            other => panic!("expected ParsedValue::Seq, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_vec_u64_and_bool_from_csv() {
+        match parse_value("1,2,18446744073709551615", &vec_of("u64")).unwrap() {
+            ParsedValue::Seq(items) => {
+                assert!(matches!(items[2], ParsedValue::U64(u64::MAX)));
+            },
+            other => panic!("expected ParsedValue::Seq, got {other:?}"),
+        }
+        match parse_value("true,false, true", &vec_of("bool")).unwrap() {
+            ParsedValue::Seq(items) => {
+                assert!(matches!(items[0], ParsedValue::Bool(true)));
+                assert!(matches!(items[1], ParsedValue::Bool(false)));
+                assert!(matches!(items[2], ParsedValue::Bool(true)));
+            },
+            other => panic!("expected ParsedValue::Seq, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_vec_u128_empty_string_is_empty_list() {
+        for raw in ["", "  "] {
+            match parse_value(raw, &vec_of("u128")).unwrap() {
+                ParsedValue::Seq(items) => assert!(items.is_empty(), "{raw:?} must be empty"),
+                other => panic!("expected ParsedValue::Seq, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_vec_u128_reports_the_offending_element() {
+        let err = parse_value("300,seven,700", &vec_of("u128")).unwrap_err();
+        assert!(err.starts_with("Element [1]:"), "got: {err}");
+        assert!(err.contains("seven"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_vec_u128_display_is_bracketed_list() {
+        let parsed = parse_value("300,700", &vec_of("u128")).unwrap();
+        assert_eq!(parsed.to_string(), "[300, 700]");
+    }
+
+    #[test]
+    fn parse_vec_u8_and_u32_keep_their_existing_representation() {
+        assert!(matches!(
+            parse_value("1,2", &vec_of("u8")).unwrap(),
+            ParsedValue::ByteArray(_)
+        ));
+        assert!(matches!(
+            parse_value("1,2", &vec_of("u32")).unwrap(),
+            ParsedValue::U32Array(_)
+        ));
     }
 }

--- a/spel-cli/src/parse.rs
+++ b/spel-cli/src/parse.rs
@@ -16,7 +16,7 @@ pub enum ParsedValue {
     U32Array(Vec<u32>),         // [u32; N] / ProgramId
     ByteArrayVec(Vec<Vec<u8>>), // Vec<[u8; 32]>
     StringVec(Vec<String>),     // Vec<String>
-    Seq(Vec<ParsedValue>),      // Vec<T> for any other primitive T (u64, u128, bool)
+    Seq(Vec<ParsedValue>),      // Vec<u64> / Vec<u128> / Vec<bool>, one element per entry
     None,                       // Option::None
     Some(Box<ParsedValue>),     // Option::Some
     Raw(String),                // fallback
@@ -302,16 +302,18 @@ fn parse_vec(raw: &str, elem_type: &IdlType) -> Result<ParsedValue, String> {
             }
         },
         // Vec<u64> / Vec<u128> / Vec<bool> — comma-separated values, parsed element by
-        // element with the primitive parser; an empty (or whitespace-only) string is an
-        // empty list.
+        // element with the primitive parser. An empty (or whitespace-only) string is an
+        // empty list; an empty element inside a non-empty list (`"1,,2"`, `","`) is an
+        // error rather than being silently dropped.
         IdlType::Primitive(p) if p == "u64" || p == "u128" || p == "bool" => {
+            if raw.trim().is_empty() {
+                return Ok(ParsedValue::Seq(Vec::new()));
+            }
             let mut items = Vec::new();
-            for (i, part) in raw
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .enumerate()
-            {
+            for (i, part) in raw.split(',').map(str::trim).enumerate() {
+                if part.is_empty() {
+                    return Err(format!("Element [{}]: empty element in Vec<{}>", i, p));
+                }
                 let item =
                     parse_primitive(part, p).map_err(|e| format!("Element [{}]: {}", i, e))?;
                 items.push(item);
@@ -507,6 +509,20 @@ mod tests {
                 other => panic!("expected ParsedValue::Seq, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn parse_vec_rejects_empty_elements() {
+        for (raw, idx) in [(",", 0), ("1,,2", 1), ("1, ,2", 1), ("1,2,", 2), (",1", 0)] {
+            let err = parse_value(raw, &vec_of("u64")).unwrap_err();
+            assert!(
+                err.starts_with(&format!("Element [{idx}]:")),
+                "{raw:?} -> {err}"
+            );
+            assert!(err.contains("empty element"), "{raw:?} -> {err}");
+        }
+        let err = parse_value("true,,false", &vec_of("bool")).unwrap_err();
+        assert!(err.starts_with("Element [1]:"), "got: {err}");
     }
 
     #[test]

--- a/spel-cli/src/serialize.rs
+++ b/spel-cli/src/serialize.rs
@@ -104,6 +104,13 @@ fn to_dynamic_value(ty: &IdlType, val: &ParsedValue) -> Result<DynamicValue, Ser
                 vals.iter().map(|v| DynamicValue::U32(*v)).collect(),
             ))
         },
+        (IdlType::Vec { vec: elem_ty }, ParsedValue::Seq(items)) => {
+            let elements: Result<Vec<_>, _> = items
+                .iter()
+                .map(|item| to_dynamic_value(elem_ty, item))
+                .collect();
+            Ok(DynamicValue::Seq(elements?))
+        },
         (IdlType::Option { option: _ }, ParsedValue::None) => Ok(DynamicValue::None),
         (IdlType::Option { option }, ParsedValue::Some(inner)) => Ok(DynamicValue::Some(Box::new(
             to_dynamic_value(option, inner)?,
@@ -674,5 +681,83 @@ mod tests {
 
         let result = serialize_to_risc0(0, &[(&ty, &val)]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn to_dynamic_value_vec_u128_seq_has_length_prefix_and_four_words_per_element() {
+        let ty = IdlType::Vec {
+            vec: Box::new(IdlType::Primitive("u128".to_string())),
+        };
+        let val = parse_value("300,700", &ty).unwrap();
+
+        let dv = to_dynamic_value(&ty, &val).unwrap();
+        let words = risc0_zkvm::serde::to_vec(&dv).unwrap();
+        // length prefix, then each u128 as four little-endian u32 words
+        assert_eq!(words, vec![2, 300, 0, 0, 0, 700, 0, 0, 0]);
+    }
+
+    #[test]
+    fn to_dynamic_value_empty_vec_u128_is_zero_length_seq() {
+        let ty = IdlType::Vec {
+            vec: Box::new(IdlType::Primitive("u128".to_string())),
+        };
+        let val = parse_value("", &ty).unwrap();
+
+        let dv = to_dynamic_value(&ty, &val).unwrap();
+        let words = risc0_zkvm::serde::to_vec(&dv).unwrap();
+        assert_eq!(words, vec![0]);
+    }
+
+    #[test]
+    fn serde_roundtrip_vec_u64_u128_bool() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        enum TestInstruction {
+            Vecs {
+                a: Vec<u64>,
+                b: Vec<u128>,
+                c: Vec<bool>,
+                d: Vec<u128>,
+            },
+        }
+
+        let vec_u64 = IdlType::Vec {
+            vec: Box::new(IdlType::Primitive("u64".into())),
+        };
+        let vec_u128 = IdlType::Vec {
+            vec: Box::new(IdlType::Primitive("u128".into())),
+        };
+        let vec_bool = IdlType::Vec {
+            vec: Box::new(IdlType::Primitive("bool".into())),
+        };
+
+        let a = parse_value("1,18446744073709551615", &vec_u64).unwrap();
+        let b = parse_value("300,700,340282366920938463463374607431768211455", &vec_u128).unwrap();
+        let c = parse_value("true,false", &vec_bool).unwrap();
+        let d = parse_value("", &vec_u128).unwrap();
+
+        let words = serialize_to_risc0(
+            0,
+            &[
+                (&vec_u64, &a),
+                (&vec_u128, &b),
+                (&vec_bool, &c),
+                (&vec_u128, &d),
+            ],
+        )
+        .unwrap();
+
+        let instruction: TestInstruction =
+            TestInstruction::deserialize(&mut Deserializer::new(words.as_ref()))
+                .expect("deserialization must succeed");
+
+        assert_eq!(
+            instruction,
+            TestInstruction::Vecs {
+                a: vec![1, u64::MAX],
+                b: vec![300, 700, u128::MAX],
+                c: vec![true, false],
+                d: vec![],
+            }
+        );
     }
 }


### PR DESCRIPTION
## Description

`spel` only had list parsers for `Vec<u8>` and `Vec<u32>` (`parse_vec` in `spel-cli/src/parse.rs`). Any other `Vec<primitive>` instruction argument fell through to `ParsedValue::Raw`, and `to_dynamic_value` then failed with `type mismatch: expected Vec { vec: Primitive("u128") }, got Raw("...")` - an instruction with, say, `tranches: Vec<u128>` could not be called from the CLI at all, not even with an empty list.

This PR parses comma-separated lists for `Vec<u64>`, `Vec<u128>` and `Vec<bool>` element by element with the existing primitive parser and serializes them as a length-prefixed sequence, the same risc0 serde shape the guest deserializes. An empty (or whitespace-only) string is an empty list; a malformed element is reported with its index (`Element [1]: Invalid u128 'seven'`), and an empty element inside a non-empty list (`"1,,2"`, `","`) is an error rather than being dropped.

Verified end to end against a program whose instruction carries `tranches: Vec<u128>`: `spel --dry-run` produces instruction bytes identical to `risc0_zkvm::serde::to_vec` of the same Rust `Instruction` value for both `--tranches 300,700` and `--tranches ""`, and the same build created schedules on the public LEZ testnet whose on-chain state decodes to `[300, 700]`.

## Changes

- `spel-cli/src/parse.rs`: new `ParsedValue::Seq(Vec<ParsedValue>)` (with `Display` → `[300, 700]`); `parse_vec` arm for `u64` / `u128` / `bool` elements. `Vec<u8>` / `Vec<u32>` keep their current representations and behaviour. Note for release notes: `ParsedValue` is reachable through the `spel` lib target, so the new variant is an additive change to that enum (nothing in the workspace matches on it outside `spel-cli` itself).
- `spel-cli/src/serialize.rs`: `(Vec<T>, Seq(items))` → `DynamicValue::Seq`.
- `README.md`: row in the argument-format table.
- Tests: `parse.rs` - CSV parsing for `u128` (incl. `u128::MAX`), `u64`, `bool`; empty / whitespace-only string → empty list; empty element in a non-empty list is rejected with its index; error names the offending element; `Display`; `u8`/`u32` unchanged. `serialize.rs` - `Vec<u128>` → length prefix + four u32 words per element; empty vec → `[0]`; risc0 serde round-trip through a `Deserialize`-derived instruction with `Vec<u64>`, `Vec<u128>`, `Vec<bool>` and an empty `Vec<u128>`.

## Checklist

- [x] Builds cleanly (`cargo build --manifest-path spel-cli/Cargo.toml`)
- [x] Tests pass (`cargo test --manifest-path spel-cli/Cargo.toml`: 111 passed; `cargo test --workspace --all-targets --exclude spel --exclude spel-ffi-compile-test`: green; `cargo fmt --all --check`: clean; `cargo clippy` reports nothing in the changed hunks)
- [x] README updated (argument-format table)
- [x] New public methods have doc comments (the new enum variant is documented inline; no new public functions)
- [x] Branch is off `main`

Reviewer note: the new `parse_vec` arm returns an error on a malformed element instead of the `Raw` fallback the `u8`/`u32` arms use (that fallback exists so `serialize.rs` can retry a `u32` CSV, which the new types do not need). Happy to align either way.