### PR TITLE
test: cover chained calls (CPI) end to end through the macro

### DIFF
--- a/spel-framework-core/src/spel_output.rs
+++ b/spel-framework-core/src/spel_output.rs
@@ -205,6 +205,77 @@ mod tests {
         assert!(!AutoClaim::None.is_claimed());
     }
 
+    /// A chained call to `program_id`, carrying one pre-state marked authorized.
+    ///
+    /// Mirrors how a real caller delegates: the account is returned unchanged in
+    /// the caller's own post-states while the mutation is handed to the callee,
+    /// which executes as `executing_program_id` and so may act on accounts it owns.
+    fn call_to(program_id: u32, authorized: bool) -> ChainedCall {
+        let mut pre = nssa_core::account::AccountWithMetadata {
+            account: Account::default(),
+            account_id: nssa_core::account::AccountId::new([program_id as u8; 32]),
+            is_authorized: false,
+        };
+        pre.is_authorized = authorized;
+        ChainedCall {
+            program_id: [program_id; 8],
+            instruction_data: vec![],
+            pre_states: vec![pre],
+            pda_seeds: vec![],
+        }
+    }
+
+    #[test]
+    fn execute_carries_chained_calls() {
+        let output = SpelOutput::execute(vec![Account::default()], vec![call_to(7, false)]);
+        assert_eq!(output.post_states.len(), 1);
+        assert_eq!(
+            output.chained_calls.len(),
+            1,
+            "the call must reach the output"
+        );
+        assert_eq!(output.chained_calls[0].program_id, [7; 8]);
+    }
+
+    #[test]
+    fn execute_preserves_chained_call_order() {
+        // Order is the execution order downstream, so it must not be reshuffled.
+        let output = SpelOutput::execute(
+            vec![Account::default()],
+            vec![call_to(1, false), call_to(2, false), call_to(3, false)],
+        );
+        let ids: Vec<u32> = output
+            .chained_calls
+            .iter()
+            .map(|c| c.program_id[0])
+            .collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn execute_with_claims_carries_chained_calls() {
+        let output = SpelOutput::execute_with_claims(
+            &[Account::default()],
+            &[AutoClaim::Claimed(Claim::Authorized)],
+            vec![call_to(9, false)],
+        );
+        assert_eq!(output.post_states.len(), 1);
+        assert!(output.post_states[0].required_claim().is_some());
+        assert_eq!(output.chained_calls.len(), 1);
+        assert_eq!(output.chained_calls[0].program_id, [9; 8]);
+    }
+
+    #[test]
+    fn chained_call_pre_state_authorization_is_preserved() {
+        // LEZ grants the callee authority over accounts flagged `is_authorized`
+        // in the caller's output, so the flag must survive untouched.
+        let output = SpelOutput::execute(vec![Account::default()], vec![call_to(4, true)]);
+        assert!(
+            output.chained_calls[0].pre_states[0].is_authorized,
+            "authorization must reach the callee"
+        );
+    }
+
     /// Convenience helper: returns a `SpelOutput` with no accounts or calls.
     /// Reduces boilerplate in validity-window tests below.
     fn empty_output() -> SpelOutput {

--- a/spel-framework/tests/e2e.rs
+++ b/spel-framework/tests/e2e.rs
@@ -57,7 +57,7 @@ fn e2e_idl_generation() {
     // Top-level fields
     assert_eq!(idl.version, "0.1.0");
     assert_eq!(idl.name, "treasury");
-    assert_eq!(idl.instructions.len(), 11);
+    assert_eq!(idl.instructions.len(), 12);
 
     // initialize instruction
     let init = &idl.instructions[0];

--- a/tests/e2e/fixture_program/src/lib.rs
+++ b/tests/e2e/fixture_program/src/lib.rs
@@ -102,6 +102,39 @@ mod treasury {
         Ok(SpelOutput::execute(vec![record, owner], vec![]))
     }
 
+    /// Delegate a mutation to another program instead of performing it directly.
+    ///
+    /// This is the shape a program must use for accounts it does not own — LEZ
+    /// rule 5 only lets the *owning* program decrease a balance, and a chained
+    /// call runs with the callee as `executing_program_id`. The caller returns
+    /// the target unchanged and hands the mutation on, flagging the account
+    /// authorized so the callee inherits the authority.
+    #[instruction]
+    pub fn delegate_to_program(
+        #[account(mut, pda = literal("treasury_state"))]
+        state: AccountWithMetadata,
+        #[account(signer)]
+        authority: AccountWithMetadata,
+        target: AccountWithMetadata,
+        target_program_id: nssa_core::program::ProgramId,
+    ) -> SpelResult {
+        let mut authorized_target = target.clone();
+        authorized_target.is_authorized = true;
+
+        let call = nssa_core::program::ChainedCall {
+            program_id: target_program_id,
+            instruction_data: vec![],
+            pre_states: vec![authorized_target],
+            pda_seeds: vec![],
+        };
+
+        // `target` is returned untouched: this program never mutates it.
+        Ok(SpelOutput::execute(
+            vec![state, authority, target],
+            vec![call],
+        ))
+    }
+
     /// Initialize a private PDA — address is unique per (seed, npk, vpk) tuple.
     #[instruction]
     pub fn init_private_account(
@@ -161,6 +194,86 @@ mod treasury {
 mod tests {
     use super::*;
 
+    /// The chained-call path through the macro: a program that delegates a
+    /// mutation instead of performing it. Nothing else in the repo exercises a
+    /// non-empty `calls` vec, so this covers the `ExecuteTransformer` rewrite
+    /// and `SpelOutputParts` plumbing for that shape.
+    #[test]
+    fn delegate_emits_chained_call_to_the_target_program() {
+        let target_program: nssa_core::program::ProgramId = [42u32; 8];
+        let out = treasury::delegate_to_program(
+            make_account(false),
+            make_account(true),
+            make_account(false),
+            target_program,
+        )
+        .expect("handler should succeed");
+
+        assert_eq!(out.chained_calls.len(), 1, "one chained call expected");
+        assert_eq!(
+            out.chained_calls[0].program_id, target_program,
+            "the call must target the program the caller named"
+        );
+    }
+
+    #[test]
+    fn delegate_authorizes_the_target_for_the_callee() {
+        // LEZ derives the callee's authority from accounts flagged authorized in
+        // the caller's output; without this the callee cannot touch the account.
+        let out = treasury::delegate_to_program(
+            make_account(false),
+            make_account(true),
+            make_account(false),
+            [42u32; 8],
+        )
+        .unwrap();
+        assert!(
+            out.chained_calls[0].pre_states[0].is_authorized,
+            "target must reach the callee authorized"
+        );
+    }
+
+    #[test]
+    fn delegate_returns_the_target_unmodified() {
+        // The whole point of delegating: the caller must not mutate an account
+        // it does not own, or LEZ rejects the transaction (rules 5 and 6).
+        let target = make_account(false);
+        let out = treasury::delegate_to_program(
+            make_account(false),
+            make_account(true),
+            target.clone(),
+            [42u32; 8],
+        )
+        .unwrap();
+        assert_eq!(out.post_states.len(), 3);
+        assert_eq!(
+            out.post_states[2].account(),
+            &target.account,
+            "target must come back byte-identical"
+        );
+    }
+
+    #[test]
+    fn claims_delegate_to_program_does_not_claim_the_plain_target() {
+        // state: mut, not init  -> None
+        // authority: signer     -> ClaimedIfDefault (see LEZ rule 7)
+        // target: plain account -> None; claiming it would steal ownership
+        let claims = treasury::__claims_delegate_to_program();
+        assert_eq!(claims.len(), 3);
+        assert!(matches!(
+            &claims[0],
+            spel_framework::spel_output::AutoClaim::None
+        ));
+        assert!(matches!(
+            &claims[1],
+            spel_framework::spel_output::AutoClaim::ClaimedIfDefault(_)
+        ));
+        assert!(matches!(
+            &claims[2],
+            spel_framework::spel_output::AutoClaim::None
+        ));
+    }
+
     fn make_account(authorized: bool) -> AccountWithMetadata {
         AccountWithMetadata {
             account_id: nssa_core::account::AccountId::new([0u8; 32]),
@@ -174,7 +287,7 @@ mod tests {
         let idl = __program_idl();
         assert_eq!(idl.name, "treasury");
         assert_eq!(idl.version, "0.1.0");
-        assert_eq!(idl.instructions.len(), 11);
+        assert_eq!(idl.instructions.len(), 12);
         assert_eq!(idl.instructions[0].name, "initialize");
     }
 
@@ -183,7 +296,7 @@ mod tests {
         let idl: spel_framework::idl::SpelIdl =
             serde_json::from_str(PROGRAM_IDL_JSON).expect("PROGRAM_IDL_JSON should parse");
         assert_eq!(idl.name, "treasury");
-        assert_eq!(idl.instructions.len(), 11);
+        assert_eq!(idl.instructions.len(), 12);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Chained calls are how a SPEL program touches accounts it does not own: LEZ **rule 5** only lets
the *owning* program decrease a balance, and `validate_execution` runs a chained call with the
**callee** as `executing_program_id`, so delegating is the supported path. Authorization
propagates monotonically down the chain — "once an account is authorized at any point in the
chain it remains authorized for all subsequent calls".

`SpelOutput::execute(accounts, calls)` has always exposed this, but **every call site in the
repo passed `vec![]`**, and the only existing assertions were `chained_calls.is_empty()`. The
path was completely unexercised — no example, no test.

This came up concretely: a program needing to deduct stake from a signer hit
`UnauthorizedBalanceDecrease`, and the answer is to delegate rather than mutate. Worth having
tests before more programs depend on it.

## What this adds

**`spel-framework-core/src/spel_output.rs`** — 4 unit tests:
- calls reach `output.chained_calls` through `execute`
- and through `execute_with_claims`, alongside claims
- **order is preserved** — it is the downstream execution order
- `is_authorized` survives on a call's `pre_states`, which is what LEZ reads to grant the callee
  authority

**`tests/e2e/fixture_program`** — a `delegate_to_program` instruction plus 4 tests. This is the
first non-empty `calls` vec to go through `#[lez_program]`, so it covers the
`ExecuteTransformer` rewrite and `SpelOutputParts` plumbing for that shape:
- the call targets the program the caller named
- the target arrives at the callee authorized
- **the target comes back byte-identical** — a caller must not mutate what it does not own
  (rules 5 and 6); this is the assertion that would catch someone "fixing" a failure by editing
  the account directly
- a plain target account is **not** claimed — claiming it would take ownership of a user's account

Instruction-count assertions updated 11 → 12 in the fixture and `spel-framework/tests/e2e.rs`.

## Modelled on

The delegation shape used by `logos-co/lez-multisig` (`multisig_program/src/execute.rs` builds
`ChainedCall` with `is_authorized` set on selected target accounts) and the official
`logos-blockchain/lez-programs` — `stablecoin/open_position.rs` and `ata/transfer.rs` both
return foreign accounts unchanged and delegate the mutation.

## Scope

Host-side only: these exercise the macro-generated handler and the output types. They do **not**
run a chained call against a live sequencer — no e2e script covers CPI, and that gap remains
(related: #263 for the witness-exchange e2e gap). Verified locally: 296 tests pass, fmt and
clippy clean.
