### PR TITLE
ci: test pull requests against the merge ref, not the stale head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
       lez-rev: ${{ steps.lez-ref.outputs.LEZ_REV }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
@@ -169,8 +167,6 @@ jobs:
       RISC0_VERSION: "3.0.5"
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
@@ -217,7 +213,7 @@ jobs:
         id: spel-ref
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/head"
+            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/merge"
           else
             SPEL_REF="${{ github.sha }}"
           fi
@@ -256,8 +252,6 @@ jobs:
       RISC0_VERSION: "3.0.5"
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
@@ -304,7 +298,7 @@ jobs:
         id: spel-ref
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/head"
+            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/merge"
           else
             SPEL_REF="${{ github.sha }}"
           fi
@@ -343,8 +337,6 @@ jobs:
       RISC0_VERSION: "3.0.5"
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
@@ -385,7 +377,7 @@ jobs:
         id: spel-ref
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/head"
+            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/merge"
           else
             SPEL_REF="${{ github.sha }}"
           fi
@@ -418,8 +410,6 @@ jobs:
       RISC0_VERSION: "3.0.5"
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
@@ -460,7 +450,7 @@ jobs:
         id: spel-ref
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/head"
+            SPEL_REF="refs/pull/${{ github.event.pull_request.number }}/merge"
           else
             SPEL_REF=""
           fi

--- a/scripts/init-e2e-test.sh
+++ b/scripts/init-e2e-test.sh
@@ -14,7 +14,7 @@
 # Required Environment Variables:
 #   LSSA_DIR    - Path to logos-execution-zone directory with sequencer built
 # Optional Environment Variables:
-#   SPEL_TAG    - SPEL revision for init (e.g. refs/pull/XXX/head). If unset,
+#   SPEL_TAG    - SPEL revision for init (e.g. refs/pull/XXX/merge). If unset,
 #                 spel init uses its hardcoded default (branch = "main").
 
 set -euo pipefail
@@ -88,7 +88,9 @@ cd "$WORK_DIR"
 
 # ─── Step 1: spel init — default LEZ, optional SPEL override ─────────────
 # Always uses DEFAULT LEZ resolution (no --lez-tag) to test init.rs defaults.
-# On PRs, SPEL_TAG is set so the scaffolded project uses the PR's framework code.
+# On PRs, SPEL_TAG is set to the PR's *merge* ref, so the scaffolded project
+# uses the PR's framework code as it would land: the PR merged into current
+# main, matching what the runner has checked out.
 # On main pushes, SPEL_TAG is unset so the default refs are tested.
 # SPEL_GIT is always set in CI (the repo's own URL) so forks test their own
 # code; only local runs without SPEL_GIT exercise the built-in default URL.

--- a/scripts/multisig-e2e-test.sh
+++ b/scripts/multisig-e2e-test.sh
@@ -20,7 +20,7 @@
 #   LEZ_TAG     - LEZ revision/tag to test against
 #   LSSA_DIR    - Path to logos-execution-zone directory with sequencer built
 # Optional Environment Variables:
-#   SPEL_TAG    - SPEL revision for init (e.g. refs/pull/XXX/head)
+#   SPEL_TAG    - SPEL revision for init (e.g. refs/pull/XXX/merge)
 #   SPEL_GIT    - SPEL git URL for init (fork testing)
 #   SPEL_BIN    - Path to the spel binary (default /tmp/lssa/target/release/spel)
 


### PR DESCRIPTION
## The symptom

#266 is failing CI on a file it could not possibly have:

```
scripts/multisig-e2e-test.sh: No such file or directory
Process completed with exit code 127
```

That script arrived in #267, which merged *after* #266 branched. The PR's own change — Vec argument parsing — is unrelated and its unit and E2E jobs pass.

## The cause

Five sequencer-backed jobs override the checkout:

```yaml
- uses: actions/checkout@v4
  with:
    ref: ${{ github.event.pull_request.head.sha || github.sha }}
```

On a `pull_request` event the *workflow definition* comes from main, so the job list is current and knows about the new test. The *working tree* is the PR's branch tip, which predates it. `unit-tests` and `e2e-tests` never had the override and check out the merge ref, which is exactly why they went green on the same commit — making this look like the contributor's fault when it isn't.

This is not specific to #266. Nine other open PRs (#249, #248, #227, #213, #212, #174, #137, #86, #84) lack that script at their head today and would fail identically. It recurs every time a test script is added, and no contributor can prevent it.

The quieter half: those jobs test each PR against whatever base it branched from, so a PR can go green while being broken against current `main`.

## The change

**Checkout** — drop the override. `actions/checkout` with no `ref:` already resolves to the merge ref on `pull_request` and the pushed commit on `push`, which is what the `||` expression was hand-rolling, minus the staleness.

**`SPEL_REF`** — moved from `/head` to `/merge` in the same four jobs. This one is load-bearing rather than cosmetic: it flows to `spel init --spel-rev` and lands in the scaffolded guest manifest as

```toml
spel-framework = { git = "...", rev = "refs/pull/N/head" }
```

so it decides which framework the guest binary compiles against. Left at `/head` while the checkout moved to `/merge`, a run would take its scripts from the merged tree and its framework from the stale head. The two halves disagreeing is worse than both being stale, so they move together.

Cargo resolves the merge ref — checked before proposing it:

```
source = "git+https://github.com/logos-co/spel.git?rev=refs%2Fpull%2F266%2Fmerge#bfa407f851ccb6..."
```

`bfa407f8` is the commit `git ls-remote https://github.com/logos-co/spel.git refs/pull/266/merge` reports.

## One deliberate behaviour change

`refs/pull/N/merge` exists only while a PR is conflict-free. A conflicted PR will now fail to resolve the ref instead of testing against a base it no longer merges into.

I think that is right — a green check on a conflicted PR describes a tree nobody will ever ship — but it is a change rather than a fix, and worth agreeing to explicitly rather than meeting in the wild. Happy to keep the old fallback for that case if you would rather it degrade quietly.

## Verification

The proof is this PR's own checks: it exercises the changed workflow. Beyond that I would want one green run on #266 (which needs this merged first, since workflow changes on a PR branch do not apply to *other* PRs).

Nothing here changes what is tested, only which tree it is tested on — the PR's code, merged with current main, consistently on both the script and framework sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9qsH6Um6shweCPEN3Z6ph