### PR TITLE
fix(cli): diagnose raw guest ELFs in program-id

### DIFF
--- a/spel-cli/src/inspect.rs
+++ b/spel-cli/src/inspect.rs
@@ -1,10 +1,39 @@
-//! Binary inspection — extract ProgramId from ELF binaries.
+//! Binary inspection — extract ProgramId from program binaries.
 
 use crate::hex::hex_encode;
 use nssa::program::Program;
 use std::fs;
 
-/// Extract and print ProgramIds from one or more ELF binary files.
+/// Magic bytes of a raw RISC-V ELF as produced by
+/// `cargo build --target riscv32im-risc0-zkvm-elf` for a guest crate.
+const ELF_MAGIC: &[u8] = b"\x7fELF";
+
+/// Magic bytes of the `risc0_binfmt::ProgramBinary` wrapper the wallet and
+/// sequencer consume — the format `spel program-id` actually requires. The
+/// guest build emits it as the `.bin` artefact beside the raw ELF (for
+/// example `.../riscv32im-risc0-zkvm-elf/docker/<name>.bin`).
+const R0BF_MAGIC: &[u8] = b"R0BF";
+
+/// A one-line diagnosis for the common wrong-input case: a raw guest ELF
+/// where the R0BF-wrapped `.bin` is expected. Returns `None` for anything
+/// else, leaving the generic load error unexplained.
+fn raw_elf_hint(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(R0BF_MAGIC) {
+        return None;
+    }
+    if bytes.starts_with(ELF_MAGIC) {
+        Some(
+            "this is a raw RISC-V ELF; spel program-id expects the R0BF \
+             ProgramBinary wrapper — point it at the .bin artefact the guest \
+             build emits beside the ELF (e.g. \
+             .../riscv32im-risc0-zkvm-elf/docker/<name>.bin)",
+        )
+    } else {
+        None
+    }
+}
+
+/// Extract and print ProgramIds from one or more program binary files.
 ///
 /// `format`:
 /// - `None` / `"text"` — human-readable multi-line output (default)
@@ -15,7 +44,7 @@ use std::fs;
 pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
     if paths.is_empty() {
         eprintln!("Usage: spel program-id <FILE> [FILE...]");
-        eprintln!("  Prints the ProgramId ([u32; 8]) for each ELF binary.");
+        eprintln!("  Prints the ProgramId ([u32; 8]) for each program binary (R0BF).");
         eprintln!();
         eprintln!("Options:");
         eprintln!("  --format <fmt>   Output format: text (default) | hex | json");
@@ -41,6 +70,7 @@ pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
                 continue;
             },
         };
+        let looks_like_raw_elf = raw_elf_hint(&bytes);
         match Program::new(bytes.into()) {
             Ok(program) => {
                 let id = program.id();
@@ -79,10 +109,45 @@ pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
             },
             Err(e) => {
                 eprintln!("❌ {}: failed to load as program: {:?}", path, e);
+                if let Some(hint) = looks_like_raw_elf {
+                    eprintln!("   Hint: {}", hint);
+                }
             },
         }
     }
     if fmt == "json" && paths.len() > 1 {
         println!("\n]");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A raw guest ELF — the exact wrong input from issue #240 — must be
+    /// recognised and produce a hint naming the R0BF `.bin` artefact; the
+    /// `Program::new` failure alone said only `Malformed ProgramBinary`.
+    #[test]
+    fn hints_on_raw_guest_elf() {
+        let raw_elf = b"\x7fELF\x02\x01\x01\x00rest-of-guest";
+        let hint = raw_elf_hint(raw_elf).expect("raw ELF must be diagnosed");
+        assert!(hint.contains("raw RISC-V ELF"));
+        assert!(hint.contains("R0BF"));
+        assert!(hint.contains(".bin"));
+    }
+
+    /// An already-wrapped R0BF binary is the expected input: never hinted at
+    /// (if it fails to decode, that is a different problem than #240).
+    #[test]
+    fn no_hint_for_r0bf_wrapped_binary() {
+        assert!(raw_elf_hint(b"R0BF\x00\x00\x00\x01wrapped").is_none());
+    }
+
+    /// Anything else (truncated files, text, empty input) keeps the generic
+    /// error without a speculative hint.
+    #[test]
+    fn no_hint_for_unrecognized_bytes() {
+        assert!(raw_elf_hint(b"").is_none());
+        assert!(raw_elf_hint(b"not a binary at all").is_none());
     }
 }

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -447,7 +447,9 @@ pub async fn run() {
         eprintln!();
         eprintln!("Commands that don't need --idl:");
         eprintln!("  init <name>              Scaffold a new SPEL project");
-        eprintln!("  program-id <FILE> [FILE...]  Extract ProgramId from ELF binary(ies)");
+        eprintln!(
+            "  program-id <FILE> [FILE...]  Extract ProgramId from program .bin (R0BF) binary(ies)"
+        );
         eprintln!("  inspect <ACCOUNT-ID> --idl <IDL> --type <TYPE>   Decode account data");
         eprintln!("  generate-idl [PATH]      Generate IDL JSON from a program source file or project directory");
         eprintln!();


### PR DESCRIPTION
`spel program-id` requires the R0BF `ProgramBinary` wrapper that `risc0_binfmt` defines. Feeding it the raw RISC-V ELF from `cargo build --target riscv32im-risc0-zkvm-elf` fails with `InvalidProgramBytecode(Malformed ProgramBinary)`, and nothing in the error, the help text, or the docs names the format or the artefact to use instead. The help text in fact said "from ELF binary(ies)", pointing users at the exact input that cannot work.

This sniffs the input magic on the failure path: an ELF header gets a one-line hint pointing at the wrapped `.bin` the guest build emits beside the ELF (`.../riscv32im-risc0-zkvm-elf/docker/<name>.bin`). R0BF inputs and unrecognized bytes keep the generic error unchanged. Help and usage text corrected to say R0BF.

Reproduced on current `main` (lee v0.2.4 `Program::new` decodes via `ProgramBinary`): the bare error above is the entire output today; with this change the same input adds the hint line. Three unit tests cover the hint's magic-byte discrimination (`hints_on_raw_guest_elf`, `no_hint_for_r0bf_wrapped_binary`, `no_hint_for_unrecognized_bytes`); full lib suite green.

Closes #240 (my own issue, filed while building an LP-0017 submission).